### PR TITLE
fix: only track on tag push

### DIFF
--- a/admin/policies/push/tag_driven_module_version_release.rego
+++ b/admin/policies/push/tag_driven_module_version_release.rego
@@ -9,12 +9,12 @@ module_version := "999999999999999.99999999999999.99999999999" {
     propose
 }
 
-propose { 
-  not is_null(input.pull_request) 
+propose {
+  input.push.branch != ""
+  input.push.tag == ""
 }
 
-track { 
-  module_version != "999999999999999.99999999999999.99999999999"
+track {
   not propose
 }
 


### PR DESCRIPTION
This works because when we push to a branch, the tag is empty and the branch has a name:

```json
{
  "push": {
    "affected_files": ["main.tf", "variables.tf"],
    "author": "Apollorion",
    "branch": "ansible-support",
    "created_at": 1730818231000000000,
    "hash": "f4269beece561ed9d89cda5f4138b157e04a5361",
    "message": "feat: support ansible",
    "tag": ""
  }
}
```

However, when we push a tag (AKA release the code) the branch is empty and the tag has a value:
```json
{
  "push": {
    "affected_files": ["README.md", "examples/full/main.tf", "main.tf", "variables.tf"],
    "author": "Apollorion",
    "branch": "",
    "created_at": 1730814092000000000,
    "hash": "467e55758a6ae67c176a30c30530b2e3740bf304",
    "message": "feat: add ability to add hooks (#10)",
    "tag": "v0.8.0"
  }
}
```

This even works when we merge to main, since we're not tagging.