### PR TITLE
eks cluster updates

### DIFF
--- a/admin/contexts_kubernetes.tf
+++ b/admin/contexts_kubernetes.tf
@@ -8,7 +8,7 @@ resource "spacelift_context" "k8s_example" {
 resource "spacelift_environment_variable" "aws_region" {
   context_id  = spacelift_context.k8s_example.id
   name        = "TF_VAR_aws_region"
-  value       = "eu-west-1"
+  value       = "us-east-1"
   write_only  = false
   description = "AWS region to deploy the EKS cluster"
 }
@@ -56,7 +56,7 @@ resource "spacelift_environment_variable" "cluster_name" {
 resource "spacelift_environment_variable" "cluster_version" {
   context_id  = spacelift_context.k8s_example.id
   name        = "TF_VAR_cluster_version"
-  value       = "1.30"
+  value       = "1.35"
   write_only  = false
   description = "Version of the EKS cluster"
 }

--- a/kubernetes/aws/backstage/db-deployment.yaml
+++ b/kubernetes/aws/backstage/db-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: backstage
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_HOST
+              value: postgres.backstage
+            - name: POSTGRES_PORT
+              value: "5432"
+          envFrom:
+            - secretRef:
+                name: postgres-secrets
+          image: postgres:13.2-alpine
+          imagePullPolicy: IfNotPresent
+          name: postgres
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgresdb
+              subPath: data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: postgresdb
+          persistentVolumeClaim:
+            claimName: postgres-storage-claim

--- a/kubernetes/aws/backstage/db-pvc.yaml
+++ b/kubernetes/aws/backstage/db-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-storage-claim
+  namespace: backstage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3
+  resources:
+    requests:
+      storage: 2G

--- a/kubernetes/aws/backstage/db-service.yaml
+++ b/kubernetes/aws/backstage/db-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: backstage
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: postgres
+  sessionAffinity: None
+  type: ClusterIP

--- a/kubernetes/aws/backstage/deployment.yaml
+++ b/kubernetes/aws/backstage/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: backstage
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: backstage
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: postgres-secrets
+            - secretRef:
+                name: backstage-secrets
+          image: 234878555361.dkr.ecr.us-east-1.amazonaws.com/backstage:v2.0.0
+          imagePullPolicy: Always
+          name: backstage
+          ports:
+            - containerPort: 7007
+              name: http
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/aws/backstage/kustomization.yaml
+++ b/kubernetes/aws/backstage/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: backstage
+resources:
+  - namespace.yaml
+  - db-pvc.yaml
+  - db-deployment.yaml
+  - db-service.yaml
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/aws/backstage/namespace.yaml
+++ b/kubernetes/aws/backstage/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage

--- a/kubernetes/aws/backstage/service.yaml
+++ b/kubernetes/aws/backstage/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: backstage
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Deploy eks with 1.35. This will reduce hourly cost from .50 to .10
Move to us region for less latency

Pulled all manifests from demo eks cluster and converted to code to deploy backstage with tf

Did PG dump on current Postgres pod created out of iac, also copied volume, although not needed.  

After deploying I will scale backstage to zero and update postgres pod then scale up. 
Tested manifests in my k3s cluster with image pull and pg dump, looks identical to demo account 