### PR TITLE
feat: rotate SOPS KMS encryption key

### DIFF
--- a/kubernetes/aws/.sops.yaml
+++ b/kubernetes/aws/.sops.yaml
@@ -1,5 +1,5 @@
 creation_rules:
-  - kms: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
+  - kms: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
 
 secrets:
   - catalog/secret.yaml

--- a/kubernetes/aws/catalog/secret.yaml
+++ b/kubernetes/aws/catalog/secret.yaml
@@ -1,22 +1,17 @@
-apiVersion: ENC[AES256_GCM,data:8eU=,iv:JoXcyrPUvHZgjQGn3zNw2kjne5/nvFMvQ0JX1KZOCys=,tag:ip9YJRXRwKwbhDBguhTNjQ==,type:str]
-kind: ENC[AES256_GCM,data:CAH3VzXp,iv:O99qqj7c74GniHScFrHT+w6UHX/CtuxvaAg0NPZnySM=,tag:EbW47Ib2wSnd8bzvffNi+Q==,type:str]
+apiVersion: ENC[AES256_GCM,data:b6w=,iv:h0cK6nh4/Yy5Z3xP+5PwwXGrT75t7e5ZN8uTwS1lIog=,tag:5pIimNyoO8ikGEMdWkEfBw==,type:str]
+kind: ENC[AES256_GCM,data:DTWqpRg6,iv:1DsobqqgU7M9AI5hdpB727f+hsE5i2aD52T341yT+48=,tag:IQgy8Zi+ms6gAo4VdCpnTw==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:zFVe9nPw/xbxIQ==,iv:eakv5/LiSFg67abc3FYO2mZtwnY5XCHVXcoLCqHwS94=,tag:lTCV/Gdy3PTQ/5vRSzs5Ow==,type:str]
+    name: ENC[AES256_GCM,data:Cq/lG8sjpoYT8Q==,iv:bieMxNoeAoShQj3f1x51mhg7WlCGoutL39BOhMTevvA=,tag:4hdOyFGh5Hfjs2rvLLSKiA==,type:str]
 data:
-    username: ENC[AES256_GCM,data:WOWOncWJjn/jKvQJXcEnmQ==,iv:VbcExt7q7sLBQnGWQzZzRqZLrqLulERK7gFPv9pELIo=,tag:L4lKnhKc0klvbEgZ5ytdSg==,type:str]
-    password: ENC[AES256_GCM,data:P635WuWldMpfejdt388CvzIajE4fIK4y,iv:i6kGZYlucbTKStY5BO7fqjUv8HSzpZcM6IIOOM85yhw=,tag:nmGNYKOuZbsJ/RhODbyRmQ==,type:str]
+    username: ENC[AES256_GCM,data:AveUJcltFHgtrv2o98lsig==,iv:zsxhabPp5u1FH/mc7LukyasJac9OPapI2I8Rpc4Hwzk=,tag:EYQ2X3ps8OKbAgodGlVmeQ==,type:str]
+    password: ENC[AES256_GCM,data:S+8ssVq0jberrNjNHCd1LZy7WWoeVdum,iv:psgy+4fvm0MyoocLfTM53IybJQFSIIFFgf+uRRpuw6s=,tag:0gCPcT5OH2jPn6X+A+aKGg==,type:str]
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
-          created_at: "2024-11-08T15:10:26Z"
-          enc: AQICAHhWR/cL6re9GRvzeHMPbvB69g/BhSB9ZWifRozqB8kD1wESOOCVX2ixZwut8AxsDR4XAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMSBd1m+q99fPqwCEqAgEQgDusYGHhodIyvSz66sb8XXIA6qIZgT86Yk4tWEQ7HdEKINHNDNePSvO5cxfWZUAy2wJfRG7OC6FPG0yN4Q==
+        - arn: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
+          created_at: "2026-05-09T01:06:45Z"
+          enc: AQICAHgY705ep75advMMNqjqFAU9HqzlXqPTLCbJkjBlZDv5CAFJGlH2UvmoAe+26urqnjRdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMnUAs7TO+1gQZgavUAgEQgDvmRgsQYadGplS0gxlcdnW4TbUCSir7Gl7j1sLcbcEUkRCLtE+CP7vMSYQCaVHDSxbcUbX/0OV8Ewlcpw==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2024-11-08T15:10:27Z"
-    mac: ENC[AES256_GCM,data:RbUDdFCfacnluzXBrb0wecvTRAhMqkfuwtnjiTm4Khyx6qS73GYXSR9LLY5I05E3dn43Og1U6fDobZH+nnmALBvKpobD2Br9BCeWGvcLT9yeFQ3gf+dd8DA6mm1o7vLQRdFhELcLdk2NDCu595Ygs/6JwqmPcH/8qCZcCsda8lE=,iv:tLvbMXKQtO2pksuYfX2HkzjtKgsy7O1ANn1EQWp8ynU=,tag:XSv+yaehFGsZdjimKCRSCg==,type:str]
-    pgp: []
+    lastmodified: "2026-05-09T01:06:46Z"
+    mac: ENC[AES256_GCM,data:g4rJ7ipw1nLkFwBMB2mOtnIiROSazQKSY1Oqo6yPbQVsXbJOLqKyfL0dqF23zpLhNdNRpmio7ba+03mkGQCqAJN+bTlrqNWGiI5Wa4M9Nzd4Z69IYa/71e1wGuuj/cU/IKNvrCJvSsM50l/6EdUUpHWjgf8/HKmLzZz9813UZxI=,iv:C0tyridAV+BwzOaYV07myO/J+uPiMlupVvbA3E2286c=,tag:y8g4wMmQY1lB0/6BSO/Rlw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.12.2

--- a/kubernetes/aws/orders/mysql.yaml
+++ b/kubernetes/aws/orders/mysql.yaml
@@ -1,55 +1,49 @@
----
-apiVersion: ENC[AES256_GCM,data:rN1O+E/tXQ==,iv:zJGYHvhYSNZ0wqpsaYkOt6+J5qDhF/atZMIPK6sWg5o=,tag:smVml2Q2YFXHlvHbTZH8IA==,type:str]
-kind: ENC[AES256_GCM,data:aM+SwndhkObfEA==,iv:2I9lsb4XlMfFbXgkgcJEMbaRuWSV9WOeysSxBsCQFw0=,tag:jZGuF13CshWL41wiCVZ1hQ==,type:str]
+apiVersion: ENC[AES256_GCM,data:7rGv8kObTg==,iv:32nYlZloFQCYFGaS/Gfqp7RKnz8zhzutC6m0FL7Y7xY=,tag:ugq6jbE/X1mfrRBpYOMTfQ==,type:str]
+kind: ENC[AES256_GCM,data:aGyj0Xf271SbqQ==,iv:BiQZJssDJNu4Gu15eBN4JfkQmVbaXSteCr+snKAEsWM=,tag:0waXQRTOReGxIntK49v8jA==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:76y3HleZg2OX8pnj,iv:oxg5pb7CiHLC6O8+gS6V9Vsrm6HukkGa4BRunF/l5WM=,tag:sYrpo3hA6H+ZNwRzxd5FIA==,type:str]
+    name: ENC[AES256_GCM,data:jbL9XJVJdHhbjdoa,iv:EMdnQptxRFZzC5Rg/psXVTHS0G+5sz1OWcy9dOI8a0I=,tag:P+oqXoR/Oitv5Um7COaYcg==,type:str]
     labels:
-        app.kubernetes.io/name: ENC[AES256_GCM,data:hp+B5kT7,iv:brEXQiS0H0GiK7ZfMR7ELrKEColMwKrXkM8o/KPUYQA=,tag:/ocNReElz1H7MPn81yJOhg==,type:str]
-        app.kubernetes.io/team: ENC[AES256_GCM,data:YpjxoSuggGQ=,iv:TSYV4Vdn6ozANk8pPVY3cd2XAOVLsGkh6Zt/qWpJICE=,tag:JFEIRYAaA3DIMFRb0RVG3A==,type:str]
+        app.kubernetes.io/name: ENC[AES256_GCM,data:E2C/+oUO,iv:POb/FweDffo/a4GFChNlRp/KYREfm/BQzGdKl7X9nWc=,tag:mn9GXJsdJfJVY2JDANarlw==,type:str]
+        app.kubernetes.io/team: ENC[AES256_GCM,data:U/7Qz3ez4/Q=,iv:ER2oH+Yh8REfiyRQLO30DV3s7aOcPIZrS7f6aKwwIKw=,tag:IkfWMoDnCzi9l/b0Pe/k9A==,type:str]
 spec:
-    replicas: ENC[AES256_GCM,data:gQ==,iv:msTj0vC5GusvP9/8sx2wkiIFDgdI3kiFjS1tMWBqgzo=,tag:Fbxw2Ca//mSzXQqf+6bdzQ==,type:int]
+    replicas: ENC[AES256_GCM,data:iw==,iv:0+yYv40aOYjvN8j5T+wNNbvLO/OO1FdypeWFSfiTpJg=,tag:MhebJeYT7Q5Bggskya1tWQ==,type:int]
     selector:
         matchLabels:
-            app.kubernetes.io/name: ENC[AES256_GCM,data:O3MpPRqk,iv:88Un6FMUi/WGYYeM3lHe6kghCrjzqE0FpOyDMaenLyM=,tag:nGu7HQP+jZKDiScTa1B9cQ==,type:str]
-            app.kubernetes.io/instance: ENC[AES256_GCM,data:Q+qj1nFd,iv:OqaKGmaKyIFCFL9Erfl2vRu1mcgonKqIiK0dPUdu284=,tag:Nj3Dz/Mn41tQB/lkjAHJ0w==,type:str]
-            app.kubernetes.io/component: ENC[AES256_GCM,data:6nT+sPk=,iv:J1GBn6FvssrnaIPcOOnurySrjjex2qiK4ie2C8MV7yE=,tag:kNVWgFpzSC0uN24XLp2ezg==,type:str]
+            app.kubernetes.io/name: ENC[AES256_GCM,data:KFzH6jxq,iv:yEytrzUSHFH0QV9H9/swz9LloWnNV2su6OpSe1+p8D8=,tag:vi+JYURx3Fasn9Husc5F1g==,type:str]
+            app.kubernetes.io/instance: ENC[AES256_GCM,data:tB4INB6g,iv:nbZ9Opyk3UozDuCww3Neda5gtry6/BYE4/Whee9DHmI=,tag:X3No6K3h7PHKly4ZzP0tBw==,type:str]
+            app.kubernetes.io/component: ENC[AES256_GCM,data:G83bWAA=,iv:2nZewbgWdxB/35w9snR31xzetK5KxyjN/YDCAFXe+So=,tag:w9zzTPv2nqS7ozjJoK30fQ==,type:str]
     template:
         metadata:
             labels:
-                app.kubernetes.io/name: ENC[AES256_GCM,data:ZMgxyTGl,iv:a3reFUppE3RDsiCMG8KvJifGgLfk6uALXx4ZpjUS7rA=,tag:b51USw+RnAWTaIwsx4+RyQ==,type:str]
-                app.kubernetes.io/instance: ENC[AES256_GCM,data:TChSQwkQ,iv:5NnyYIKpfrLXHgukNQdvvQjmDPBkW6J0eDUXOU2M2y8=,tag:Ln9imNLQqh8auG5b5oajVA==,type:str]
-                app.kubernetes.io/component: ENC[AES256_GCM,data:ney56LE=,iv:sGO2q0UG5R3o+fT2ACQqvbL3ICei8CW9YrVTEnzMiV0=,tag:vMhXIyN89mzYAWxMGsqqzg==,type:str]
-                app.kubernetes.io/team: ENC[AES256_GCM,data:UjqeYvpt6AI=,iv:U2QiO8UQ3hnK9pK9KztmJFoQfmBdebsgbP1bIcPx6FA=,tag:D79N5k5wOgmUYCbhsCX3DA==,type:str]
+                app.kubernetes.io/name: ENC[AES256_GCM,data:CZcOP0/X,iv:d/zechRnWX0AP+733ehcbNXI9g8qWxtZMraUZ68vpXg=,tag:S2R8sM36SEWkpROJL07g8w==,type:str]
+                app.kubernetes.io/instance: ENC[AES256_GCM,data:hmT07e0C,iv:FfQKv51lly1UR2c1VVdj+aMqiJDqNvqqHpcC5Bcfxuk=,tag:TdzzDXovSzzeyXeTkYFE9g==,type:str]
+                app.kubernetes.io/component: ENC[AES256_GCM,data:M1AErX8=,iv:SDdeYCQKLnxlQeIHur6toygjWcZrPMNBhh7gYIaUfQY=,tag:7gXhJhNTSYhMwIHzfehuEg==,type:str]
+                app.kubernetes.io/team: ENC[AES256_GCM,data:4Pvb9uRMAgw=,iv:G2gIia3wIFB3P428O+l8vgFvsYbZ3wtJNjpg1GuGCmw=,tag:OdeegyHBTU3pXuaAcySLiQ==,type:str]
         spec:
             containers:
-                - name: ENC[AES256_GCM,data:oEzCs6M=,iv:pXezqOj3qcJsk/VQuuJhiP7Jkn+kwymAPnGw7jX7/Jc=,tag:iozeCnVnI65Eqy6ypWih1w==,type:str]
-                  image: ENC[AES256_GCM,data:B+zt0WZDaYYCF2spjVOC9XD47BlOiCSbhTM8SsJFD6F2YR4BPADk,iv:xfdpe90TSa+yM6V03ilIuUADpsBgbCAQuYTdyNG4pF0=,tag:w25qXQv6OBdXrDx5njj2Lg==,type:str]
-                  imagePullPolicy: ENC[AES256_GCM,data:uY75XaR5ubHS08m5,iv:mu8KB31UeC1tRGjKNWPbYsPr+L4VrwmwPDi8Lk2FJs8=,tag:yZiKkCVK+Tpsz/2x8+5C1g==,type:str]
+                - name: ENC[AES256_GCM,data:093XeKA=,iv:j7g1H18Z+TgRwqYR2Ur+5wx0Gd1kSXolb7zZr6jEv14=,tag:ZnpDgp0YuE9KagF+9JSwgA==,type:str]
+                  image: ENC[AES256_GCM,data:+RvFrJGOERUBA5u72rzJUBzR3vK/YzqA4gCFaTW/0jLdmpfeXue6,iv:ibzmlscZBGwxdPo9rNq1uPR4RwlJWttc5Nv0pzi+a38=,tag:ce8kdb8kSrCf4+C7hh5ykw==,type:str]
+                  imagePullPolicy: ENC[AES256_GCM,data:lpmtddhGSCgaBq8U,iv:YrHkHpqVzBI5miwcnQXAYR52114kygtLqqIvJWACVHc=,tag:EWEq5kddssxIszK4gYpW0w==,type:str]
                   env:
-                    - name: ENC[AES256_GCM,data:s4sF7KqCXuU/2Unjv/kRWkJKnQ==,iv:6XQyZE8StiDIqshm2EQ8+0A5qrNFcThERPdtJJNv04w=,tag:ujXAMlrhEaOGtzFAT+s2Ug==,type:str]
-                      value: ENC[AES256_GCM,data:ZXSJZGry62PY+jQE,iv:mh2JShHwJAlRctrOUt6UsnqUivwQt/fpHjQ+c7NWF0w=,tag:xk/2At62cVQHia23U+Ahng==,type:str]
-                    - name: ENC[AES256_GCM,data:dAC2JGMisgSxZRGbKw0=,iv:9ZZxuCuoJB+ZjSxU+uc3ra7lyEK5LQVXB3TyJkv946o=,tag:6XT8NSF9L1gHtEI3BfaewA==,type:str]
-                      value: ENC[AES256_GCM,data:ZIuWIKiK,iv:vfti7EZ1fCMtTz9Vq6qdPVBBFFo0AQMSt6OcOY+b74s=,tag:bIQuHgR2N0uJhiLkceEeaw==,type:str]
-                    - name: ENC[AES256_GCM,data:oBWgPAMtLYM0Lg==,iv:u4WXiFfwjfD+tlwqWIPqgqBJAXbOW0/UQuQ0Evg4spQ=,tag:V7bwrFLyxgL/RHDO0TLx2g==,type:str]
-                      value: ENC[AES256_GCM,data:NCoPl3m4GtK19lg=,iv:XM3Sl7eFkV6XVqhlh0lK7GooToMT0IbLXhBVJk27HxQ=,tag:F4mtdyTXeCiwmfgF8LTwdg==,type:str]
-                    - name: ENC[AES256_GCM,data:5Nlx9BDbFoxxlUb9Pgs=,iv:fY7cv0R5H8LdWnBw3fAWqeSxMmU8otU++Hg+ElaKsFs=,tag:JZ8vFvfyglq612/VHhqaqQ==,type:str]
-                      value: ENC[AES256_GCM,data:ZXVt561GEjW+rHxzI3WAwg==,iv:I+BDo5vD/kIYtlZ+lpwHi8Ko6jRjMNpQEyFEjpk4Gs8=,tag:TI1bUxAuYtq7ThMAjVelDg==,type:str]
+                    - name: ENC[AES256_GCM,data:dvOX/GTYAgu7b473SvU5r8tExA==,iv:Ho8mdmhqks/c4GCfbP8WNpOWAW+RNA3QCRM3id/VFMs=,tag:UrCczNF0G9iK/MDupKkqsg==,type:str]
+                      value: ENC[AES256_GCM,data:7TROgCbQRaJJAGjY,iv:AXAoMPDWQ86Z7xtX1CVusf8qZ8404Opt8rS5vOV64ag=,tag:zKiZTFH3Mp3gtqSmlIQ9dw==,type:str]
+                    - name: ENC[AES256_GCM,data:hSe2XXHnn6oeclCyomw=,iv:xx0r1TLnhPUlPAzfJ4NWVqlQ+ba8XGqUGGanT6GuT8U=,tag:WT7S6dARbTxv3RAXGXbI4Q==,type:str]
+                      value: ENC[AES256_GCM,data:7xvjp4BK,iv:7WdaSpHaefa9JzX/8Sc6cui5J/e1qBsR12+9ItdmP1Y=,tag:1NUfu5Re5KLNN5nqNOOKZw==,type:str]
+                    - name: ENC[AES256_GCM,data:2PZQE+CVNEyd1A==,iv:/atQuBAGOrbKnmUcsEoCmjHdWDWNTxXln/XlCB+IuJw=,tag:Rkd+VNw0G0ovAaIXFFpULQ==,type:str]
+                      value: ENC[AES256_GCM,data:5n2sY/GkJaztH3o=,iv:YJSCMVVfk3GulkdSTycRF1R75v0alQ59p452+zf7rn4=,tag:dyiTKTWxg5jTE4jyoCqisQ==,type:str]
+                    - name: ENC[AES256_GCM,data:ctUe26bl/JWMx4qXNCs=,iv:sLn6t0vdfy82UZ7EyUvTx2fbVFFZIkqQVHcfP9sZiGU=,tag:UQRnsDgLQRlMlHXz/JeCdw==,type:str]
+                      value: ENC[AES256_GCM,data:rIqp+ojeK6e1hDvx75Ur/A==,iv:aIHcxnTLAcMcPGrhRbEx8zIw9F6ajeAHVCUJ7dYAP2Q=,tag:s0N9AhjVryIwocsCo+jsSg==,type:str]
                   ports:
-                    - name: ENC[AES256_GCM,data:IM9vpT4=,iv:buFUSW1VivFbdFLIHJsoFUNvzz6sRwH4DIh57+9iIs4=,tag:tD1L3t3CwSdB9EPmdQGF9g==,type:str]
-                      containerPort: ENC[AES256_GCM,data:WOEVeg==,iv:xbTO65j3XnchIBT/f6m6WmDWOfr6tKgriEqNpk6Tykk=,tag:mGvVuJzQrPTfZ65ue15BFA==,type:int]
-                      protocol: ENC[AES256_GCM,data:ZVoL,iv:O9iFGka6q+a0mWU9wSzABwARqRUwqPxGgxNm2iHVTno=,tag:C1Ind+CWkeprd+T2zmX+ww==,type:str]
+                    - name: ENC[AES256_GCM,data:twXU09k=,iv:/PHBZalH/bYkfg2lS6NAdcboZIO6N4M38xjPI25UUJg=,tag:G4h22dodCkPo56CtHLKHWQ==,type:str]
+                      containerPort: ENC[AES256_GCM,data:EcPDug==,iv:nlV3N9M/OwZYHaJt8N7yv5DQ6xm/MJGx2ZIRnnKD9LI=,tag:dZvsdtY0NZGnbnc/SIRAaw==,type:int]
+                      protocol: ENC[AES256_GCM,data:wBHd,iv:/ixbjwyEVJ+SC4ZXk2uPglQjJoPOlBh8nPopBv04m60=,tag:RD8O+NJ/ZNG4UmjDcv8/8w==,type:str]
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
-          created_at: "2024-11-08T15:04:22Z"
-          enc: AQICAHhWR/cL6re9GRvzeHMPbvB69g/BhSB9ZWifRozqB8kD1wH6g3+hFc2FVCpT3p4c5y4IAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMUceRCWHAMH3mn/ahAgEQgDscanlNkTmgT+1tycClqyYQeAFYeCjiaWEln+rWX1vhLOCIpdzaG1GyO+rMG85vAA/8sQ8FvfMd1CtUig==
+        - arn: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
+          created_at: "2026-05-09T01:06:47Z"
+          enc: AQICAHgY705ep75advMMNqjqFAU9HqzlXqPTLCbJkjBlZDv5CAEmR78o5AWnRkVPS4T13VBnAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMxqRnBF/scNtM69SOAgEQgDt2xbTdNzaBk4u9j/N33ubpECGHRHA/CZYrXsh1y1/o5mm3ll4E4nnzDq8gaSXVNsb5FA4sxg1ODFlVIQ==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2024-11-08T15:04:23Z"
-    mac: ENC[AES256_GCM,data:FkQFVAX3HkORHqka96eGCRtxVVVbeoabTd3NoxF7QiBLjvKLTvRRad93/eDz2D8/18Oq7Mh1TOnDBC+pbtCXhjX1Q1batSwyN68nGMiRziZyC+Z7UNl8sQ6wBReiPJHXxNmBtR7ZiDPVxs27CqCNvKbTtuHU1lg3NgHAuAgz4d8=,iv:ggA4zs/G/C35A9YaFR9vIWZ7CuSOp3tywuYrgqQxt4o=,tag:qoeNuAJ4qlzmRID2ForfRg==,type:str]
-    pgp: []
+    lastmodified: "2026-05-09T01:06:48Z"
+    mac: ENC[AES256_GCM,data:JwbztlUiR2o0Ou4oZPwanS6lRrm8/Z9MiETrLu3bgE9WekrICSaoghfgAzOLks8Hia3vs4GYq7w7hdx13vxSvHQ/WYT8b/ZK9TbEiC/5P+r6CpsV7BvabjxZ5smdSW0Nm+NYCgd3uRShlpcXT40/uSV7YPnXiAC1Rkz3sseZVZU=,iv:ncRAmmjchzpKil5mA8vC4JZ0GpxQ56k1SEVKbR8v/s0=,tag:p7iq9Us+FBGdnlNPVtkmOg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.12.2

--- a/kubernetes/aws/orders/secret.yaml
+++ b/kubernetes/aws/orders/secret.yaml
@@ -1,24 +1,18 @@
----
-apiVersion: ENC[AES256_GCM,data:5zk=,iv:IC6UXBLojZYWL5zNlk7FT25VYWkBOYbEdSjJMMoRrPM=,tag:dot6p0BZzPZtzmuhKHDGsg==,type:str]
-kind: ENC[AES256_GCM,data:DowquwN3,iv:3y507G4fp3nWYgNKJhou49meKlkcW4yMiAYwwDRndgU=,tag:KM7isNgEY+Ae7sRopeF4Ng==,type:str]
+apiVersion: ENC[AES256_GCM,data:cCw=,iv:D7zMFwzZe2aUaMP8kSsMK4pXFk45T3HPDKfR4+vJcFw=,tag:1vz2jRht0oLPBaSUkz58mg==,type:str]
+kind: ENC[AES256_GCM,data:OxU+oOjl,iv:elwp7zVqnxFPtS4Zr3Wlw+0ADd+MeWUIja7hP7fskK4=,tag:R2aaFJrxoZuna0g0c06oow==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:l2ffCzyQPSGF,iv:o3EGB6rEonCskPsncQO8/F73xyhfBHkDE0oCnImvXGY=,tag:QAW38hIN66ieWKA1hw/IlQ==,type:str]
+    name: ENC[AES256_GCM,data:dSh0xZfzpnSb,iv:Fe1awNWkSkS+4tfBL0QSJPx/LF2F01eDfTsUkVmX234=,tag:hmN5oA7gMIWkbw2A78snKA==,type:str]
 data:
-    url: ENC[AES256_GCM,data:zJmPVxJoQM9gCR8gd4QTl5w/jtog0ykUGdzla+hLK0Jebb9uUnCLnz40xTipiuiVp9VPJw==,iv:hr7rcrgLPg6daU6+OqooCfwACoaXJdgUWpE8sGZnoj8=,tag:MXUFwi5bB5aIu9DO7D8hMg==,type:str]
-    username: ENC[AES256_GCM,data:1ZMGAFLmaS1QHu2Iq4XevQ==,iv:FURasZtz8lUb6Yipl50B7s5Xe2lt1tQemjuzlLOZq30=,tag:Tv+onFWs0DH/MTxQ8gBhMw==,type:str]
-    password: ENC[AES256_GCM,data:DumSM8/xXmuBdVtF/sYYNrCv6NAOryx8,iv:6XcsrPBy8D02Q91M1oFINi57QpZxx7VmKdmx13wCDWE=,tag:1ptNW8RdTiDZtSM9ZxVYJQ==,type:str]
+    url: ENC[AES256_GCM,data:7YnyLoJ+7gkn2lkckZ9UuA7EX+uiqB9Plth4T7DoYyhtDymN1zML+P9OgbUAGcwqZ8oaSA==,iv:5H9JWYuNzbmRL2Erzz7adDTkQRBrh7AVg6+IzyV722U=,tag:z7OKgVO3UwajQUS5MpPQcw==,type:str]
+    username: ENC[AES256_GCM,data:VfYoCGKb9QXufNlI7zWnfw==,iv:+iZpIi7PBsAihL4o5XZj7kZ8LVP+HWMvXQrBdl/SmJU=,tag:m5Ki0uLqLbJAfMLg2wvw4Q==,type:str]
+    password: ENC[AES256_GCM,data:8XUG1d4vzNXJVSWbAihfFVaFWy+IIpu9,iv:kHHaO0XG6JZLDLAk3NXefKrZeDOYWXlDXCvOEvclgeg=,tag:0F2PtVROIbH/zcf+4FgQwg==,type:str]
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
-          created_at: "2024-11-08T15:04:00Z"
-          enc: AQICAHhWR/cL6re9GRvzeHMPbvB69g/BhSB9ZWifRozqB8kD1wG+sCOmRx7b1Jd7k32ZlUodAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMeQZPzMgx2KYqUAqiAgEQgDuDy+yauDgpGMXaucDuiCyW5uWoIf5fqiEzfDik6cSpI50vdMzK/l2vgYJyIbi79WI03QGWqKy64LGSXw==
+        - arn: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
+          created_at: "2026-05-09T01:06:45Z"
+          enc: AQICAHgY705ep75advMMNqjqFAU9HqzlXqPTLCbJkjBlZDv5CAGe4nucZ/LVD629esu/mbaQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMI78Jn19pC/A/7NSzAgEQgDu+I1smUDsgVCzcPrioPJB/iKC54NNnzgt+so3QMZrSzorW1AlDP/3tECF3Cx1AeWYus/Box2PzCDNbzw==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2024-11-08T15:04:00Z"
-    mac: ENC[AES256_GCM,data:KdIT0MTY3V/wGNW2wNxJtkHNpQ10Z5TxcJcxDFZ8GPEWbmaZCUvSPIIKbStR2+TU0lcw0XoixqroEuQcMPVUeksIYO5ZcF8ptsSFmCm6lrl7QuZ+Ry02NWQLns/J8PeQDsl72Kb/qOni19MEcs+jI5GnLz8xlqxEHZuONJg00b0=,iv:RWXfHvPRTHK+Juo8YiwiWWbdbcoTbodxuFSlgJW1S68=,tag:hHbiuntE2VBc8ZEMVoNz9g==,type:str]
-    pgp: []
+    lastmodified: "2026-05-09T01:06:46Z"
+    mac: ENC[AES256_GCM,data:DSBnVA0184LHlY9Qtszs64non6P6KEB9EPh4P016VdNXZZXgSwlJYuDJLZg/w3n5TYxlo/YRqy238R/N3ps9+8ezzCRuWXm79C1/ZZ9Qz1Q2iXWQ1gJQI/jZRCkj7dhtmKRUHTzGqZi23raK39cVWMyVa87K3lIbjNuXVgtmuaQ=,iv:gCoUuRaw0zMKb5IxTf/zKeAWrfD6+oNPGgoODBQ2pwo=,tag:SIY1fpNCjuOf1SulDs+jTg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.12.2

--- a/kubernetes/aws/rabbitmq/secret.yaml
+++ b/kubernetes/aws/rabbitmq/secret.yaml
@@ -1,54 +1,43 @@
----
-apiVersion: ENC[AES256_GCM,data:Hs4=,iv:SsEZzDG4Occ2H7ysgii0v+hX/8ItivITeYAKCWOoaLA=,tag:yFvO0hoye8Rmaez7lIZqRQ==,type:str]
-kind: ENC[AES256_GCM,data:nIs/zQ6Y,iv:L359hjbheUvBz6vJZfIBQVX9oaHWATSjviNSVQh5rDE=,tag:NSoTx/Hjni6ax+ovHmUs/A==,type:str]
+apiVersion: ENC[AES256_GCM,data:cw0=,iv:AOmLoTar0Oh9hPe9HpJYnx8JVXmgMxgbJcJkiI3247Y=,tag:k/WG5U71PqVwinyt8fpEGw==,type:str]
+kind: ENC[AES256_GCM,data:RcLl9DlQ,iv:myXOsD9+kuSubJCqO6Br6YH2Luhn9PMUtdPjYqc64qI=,tag:L7SN5+1lQh22a6pcMavaNQ==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:vFWqjrDXSBL6WHPMMoIM,iv:ehJ9rDh03ZYfd2mS3UWihAYzhtae2WkbVVcaiFPIDD4=,tag:8Dj1YaEoJZ9eTNl+5hwJTw==,type:str]
+    name: ENC[AES256_GCM,data:LqSXsl+MeIEiR5ktsa8y,iv:oZP5QHvR0p4RrFRkUoxhvSwg6waomu1iewSyahR7ixs=,tag:72znPY2BxPGWrBdvQmOXHA==,type:str]
     labels:
-        app.kubernetes.io/name: ENC[AES256_GCM,data:T+ehfpcLhEE=,iv:Qz43LAuXa5cvYl6JO0F/b7OqTdkszScow5CRBdmVn8c=,tag:4ni0LuNNYyN51ujD2KOuqQ==,type:str]
-        app.kubernetes.io/instance: ENC[AES256_GCM,data:AoS5we6AvQc=,iv:juvPO5pRqwqv0gSNnt7LtmMzIucetCxCCmDT8Pebs4I=,tag:CtThrKvntkkbbEx4YMoC3g==,type:str]
-type: ENC[AES256_GCM,data:af4w8lyH,iv:qk2nFxQnngMHEuev6kbWMWD2FmLr04iTSY+7KJiyxQA=,tag:DfvZ/4w17R4eksxMreKlew==,type:str]
+        app.kubernetes.io/name: ENC[AES256_GCM,data:CWpSIyC6I7s=,iv:6dcBB1RLbeOeP2uaflwfi3m1g9U2PC5JiUtWjIrbcaY=,tag:+Q++4qMjvECcUuUw58o1mQ==,type:str]
+        app.kubernetes.io/instance: ENC[AES256_GCM,data:dk6L5TQxluI=,iv:48HxeH0BMNZOCEM5Gcmy2dKRADQfEMJUtD16uxiz1QQ=,tag:Ni4cp1qQbucIusDvyucOuQ==,type:str]
+type: ENC[AES256_GCM,data:NN31YMGm,iv:uzNYbLmJTxmzcu4iRMOCUGfwXxKPX0nSzgs8sQZefdI=,tag:mMpOIUZuTEHnfxgnVryLvw==,type:str]
 data:
-    rabbitmq.conf: ENC[AES256_GCM,data:bpt1+VDsL8vFiPm9AOVuZfETNrdKSgA3FbwVjBlHVMQ0zeiujd+peiPOgtEbMC4cnP76NA9AEblMrxniIQ3XYR5ORaCJAYvpp+8vpQ+zga6397j8VaLiXYa8pSTaIwBrBKOgmZx/kMKjYBWUWDVVl9Hypp4FVP/t8lHPbUD+vHQlgZMym79Q0LBPlxmJZ96HrwPG/SxjOaqfMYgwh43GiPv5oF9Wo3jvBtJgirkI3Eyrf43GiPLb2uGSRZOSh/97poVhxYU7o6SVnE+56NaKZ6wH7nCKRvx0uBSEUTKk+YVeeeJLoSnePr4qY9Mrn93mL1G/7qtadPU2EpXS+ULXV3m//PQVzUhU9mY69NZt4UsYDRU36MuqnbZt2AIFAiwI8CrY4mo9uLYXo3e9JLSxql8vTMjA/yHfSPSNoBdf5o6nypOrrKjB3I4jKW2ZfPpzmMR9ub7U3d6D2LSWl6/m1dpMysuDHv11nEj7pqM2ireP6FGypvGygzQWDCvy7GdlsQixbpzjPIq4PsXRUHCVdjMpCQOOWc/siOmHi3gJ0nCPe/g8WPBng6GYEwFSvQvLfG0gvO9ghwsJpurZeqrm+vl6BJ/aFFIK7d84DNOBFNNLvuf4dZq7ZSk05W2rJvOJqBahr/p3n7IE1qndJa0TLeTkdbwKNx67XzJ67gN3GxE+tT7jySTrAA25muiCrfnR6uWXkUPD9Y7+8wnb/3QMbKqvSAGNKnN3g55xcLTlBeG6MacCt0HqFQCNRjmgpTBG+r3wvBAhv0KVoJwL9sdVG0D21eRGfgbgBpQqSxsNyh1jfM87z7mdjgateV/UiOzf7bSGBcachuBMt3LoRnc+Lb2CznUldu5rJagLnP6Je4Zrx7d/5osxQjf0uFq3W13OQfC4gCtH0nMk7v2+G+rM2Q==,iv:95C8Fd7mGZdRdXk7YlUqdyjrt/o7gMYs69g78RrTbcU=,tag:mNNFUjnLq6qzl2xXtlU0sw==,type:str]
+    rabbitmq.conf: ENC[AES256_GCM,data:2F2h6P/8Azeku3wDBkve93Ij5zZlYxWpkgBZjrxxKcmIznDn7C7UOuLzV2KFfNEmC0s6aKlkY2coDmh6NWivdMIJjs+E/whWTlerP3BHvv+k13WCeDIiTEf8zfBX8QSk+TNWPk1AzxTkRlSD1hLhAVqNBMYR0d5ZYlu/bCMEmbjFrrKWiGth/T+CYj4pHNewqiMoMwg+fC6FG74vyTfakTt0n08V1ITGChPbGClATsGITdUMs5SZ5ld9idCKdWnBR0oCZx4TmA7RP+yt9gypJxMTdXDA7LbdwaBE8tUdjNXpFOb/IWBo9Q0FKKgVTVFL4XGG5OWP8smorR8gurUPxwim6YOC7XS0/7YodP3O1T58apqjScwJ82REPku2XX3M9KB2bb4Fni5rEJ5mKmbMfKiIBJQZPPEW4qVDUnP0ICg3AMOrZtVzJZPXmZ0Yw5bHZiy0/J0lp+CUSCzKKgIyKxE4PzBH6s2gZfNqbVaDpvrijlB1rasrbWpGcNQO9uPiedtElNznrEXcsONL0tN6ehpb929CFuxHsbGYn2UgOdP3HoNWTVorxB210WpPrUKPGaCPmeV+aqo4nA0LAWHz4LzkJxYwE8Um/8gD29OZjD9K5ir7uKZAJdPBS4R8+IgMRZiniR7ltK4lbzrAEDJLF+1ppUJAs7E7z28aiaEAW/kctRODMpatLK2WJfXQj+N6HZJQkAqnMaW6cs9ImeSgj4lKZir4YaHllk+KdmkOkL3fgsMUXvzv6tDIz4/WIMDrSM+G+JUIKy6iCcfLXla4/BQLcXrV5HjxdrgHA0T1QYyYckAbP60nH8ZrClenxgSd5CblmiLvvEATT5b7/mZ/pxR8SLLG2rWRJb2wmbp/Fy3yn4EB8BXafLdAvYVsMsms0tQ+Pj82ko4EuWzssDUk5A==,iv:M0wEV8Z9MZcByNH8iI3ieuIHnRGtcwc5fNOKgYL0Gl4=,tag:6mf74bnIea82IMeraMEppg==,type:str]
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
-          created_at: "2024-11-08T15:04:12Z"
-          enc: AQICAHhWR/cL6re9GRvzeHMPbvB69g/BhSB9ZWifRozqB8kD1wGzjbPdXFu1WDxcTmliQHGsAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbLBpt+qBbzOjxkr2AgEQgDs4uUSj8KRtD0j7lUiQJyOcFT5dlPY0d1izvBq04eumHvM7jNdZzoNWWimGYtKhpEWd7Oo19GXSPilvbA==
+        - arn: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
+          created_at: "2026-05-09T01:06:46Z"
+          enc: AQICAHgY705ep75advMMNqjqFAU9HqzlXqPTLCbJkjBlZDv5CAFOyQU/gs7PnQqGo6Dw2ioMAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMVSq9eUhP2aiV1ofPAgEQgDutb6RvAHZsSIuAJGr3958MWjw93V/Nog5rF5H5C5k4jK4cVjZKfqvoykZLAGgXMGsD6AjwMZrDqCJ6Aw==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2024-11-08T15:04:12Z"
-    mac: ENC[AES256_GCM,data:gO7xTvaJORmnIcGDm04YSBXAtz9MjrB4D6B0Fky9uboKrFdOF3cOJfdrMExKVSr92xsZp4G1X7hXY4hZa/qhmV9/6vSdL6b1KTOSNVoU7l35LiWxWsBJS7g2GysCoqA+P5l6eyz7nqb4R6V/bZbqFHGVOs+G1E5ni9wBlqes7aw=,iv:9WToYRveiK6IqdseiubIkse7CSsYuKClibeCTgYkSz0=,tag:UvtZ5q/m+W8DKGYBBKCXiA==,type:str]
-    pgp: []
+    lastmodified: "2026-05-09T01:06:47Z"
+    mac: ENC[AES256_GCM,data:aEBNH18zooH1G9DEx9EKsvU9VjonEjHbqdqKT2fepiOZgkWz0JwuMFRfHbAAPOCqBnincLzGCkq1nVfyaDEEE1OCorZFkUWsGkCMEgzyc7HUSzGNd0anE05rXFCvBpSIuJz4r2gBHqmrrypU5jg/8494Y6wr+NWVaL0rfJtyV24=,iv:cCYW3Xf2K9MtxLBbLAdIC+V2swF9iNRVRQBNnUF0lIE=,tag:NNxPQ5R+cNlulc3fwiAeog==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.12.2
 ---
-apiVersion: ENC[AES256_GCM,data:T/w=,iv:Gm4xQTRsk8weKUXP2GsN/82cV1dOUl9H9Az+wsBFTRA=,tag:kQm8ylWbdUgme8GTzu2bpA==,type:str]
-kind: ENC[AES256_GCM,data:vjrSd+Qp,iv:96a38nt0BNpQDZZAeoZg4IFKntfXNbx8e+GLT8rvvZk=,tag:HMGLWakhCE/3x4hWpxvuUg==,type:str]
+apiVersion: ENC[AES256_GCM,data:CGs=,iv:BlnflBecIxbijNmw/mv+jHo1e+EqKmP7sm/4KfcbyH0=,tag:rzH16JJ2UUu8PldLhgzcCQ==,type:str]
+kind: ENC[AES256_GCM,data:YSSyEYTK,iv:btp+HTdPBir6EC2ZWbL2x2mxb9K9nKr1K6jS3+pFljA=,tag:XNi5CwJdnR6EsC/xGOgo5A==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:gYQoKYd4O4A=,iv:g6Xv/NqIOdt0NsJDhIuxlDYJHbkOY+B2/OrcTk0pnCs=,tag:+rbahszeKtqWC5+cmvml5w==,type:str]
-    namespace: ENC[AES256_GCM,data:pLBMZpBDm2k=,iv:uPQK3j+QaXhRX5e+vPs3h7FOwx56FM1foN1seg/GWls=,tag:6ev/uX++qHYhBsyjWo0qOw==,type:str]
+    name: ENC[AES256_GCM,data:UT35AVTHQos=,iv:GuhF0NnureiK7x9Pw4e9NEEa490I2FLiX8Tc5E0MP9A=,tag:o3r92zSzz2NnaiuHGNWBbQ==,type:str]
+    namespace: ENC[AES256_GCM,data:ma5ZT9I4gIU=,iv:flr0XycJZxtJSlAFwE5myTl9V7NCQx1b+FxPl1OkEb8=,tag:HPkP35fEXh/FAUXy9grM7A==,type:str]
     labels:
-        app.kubernetes.io/name: ENC[AES256_GCM,data:Rptu3YpnBmY=,iv:yp1mOxWVxuGbVlchUTQGMsRqFNONMP7AIbcxAI3Qr+U=,tag:Zu01YJrBjo3ScZVImUKjww==,type:str]
-        app.kubernetes.io/instance: ENC[AES256_GCM,data:j1xpyNhwCJY=,iv:D2PYmaGg2GDffGrlPdZWAALCRe9Cot/atl3jny9dpbY=,tag:8J2npnx3MrZD4QOuOE0nBA==,type:str]
-type: ENC[AES256_GCM,data:RXI3G/Xq,iv:wubVUlJag6jnCH+ZrwPDQSfcOYNCeU5W13Qyg3Ppd7Y=,tag:80utpWNEVuQSkjGlBk7SHA==,type:str]
+        app.kubernetes.io/name: ENC[AES256_GCM,data:sW5xYV/m0sA=,iv:TTdrcsVBs2Xb4f4ZQPS/XicJr5Nml+9Hx1wXV9jhZdI=,tag:Ui0erZFkloCtB9l+J7zyZA==,type:str]
+        app.kubernetes.io/instance: ENC[AES256_GCM,data:FYt0fGb9ZPc=,iv:Up+18TE1Ag+10ye2/XSPNWuEBZvAA/W2Dkkeqk7dfF4=,tag:RRcCQpyNpsu3C4oKIayP8A==,type:str]
+type: ENC[AES256_GCM,data:0c1Od/db,iv:i2UKUFi9SGiNyf7SyNNi/p/Vz8aPZZwFICqyux1CaEE=,tag:r19YkEa5om3AmruA7jUuVA==,type:str]
 data:
-    rabbitmq-password: ENC[AES256_GCM,data:V40rOACGtdzQ4HWMThW2pX66Emvwud7m,iv:6dDDoOgRl7QQb+YIGu5ZLzK70RUdWsppHeT+nJyhW9g=,tag:TC4bADVAhOHO2zjZC7txiA==,type:str]
-    rabbitmq-erlang-cookie: ENC[AES256_GCM,data:jH9xZ+++m6YBADX2L0SmZM62pkm0W/BgwUSGIQUtQizuZHu4ro9QBoS5BFM=,iv:ArOBoAYcDriKPAVGB6e1m14jCot6YjVxNLak0qxgN9I=,tag:TEebpwmu5YhiP3dICbAOwQ==,type:str]
+    rabbitmq-password: ENC[AES256_GCM,data:/HUdj/WSsaik/sjLxF+rOQg1bSIkTSHL,iv:9p+yTtNS3QnrLKpG9TD6AtW/Td57T6aiUX0neVVvxxs=,tag:0FHQeF2VML/ubgpT6ge8fw==,type:str]
+    rabbitmq-erlang-cookie: ENC[AES256_GCM,data:WU/PPmEfMOQhVUNqTheLe3R/duCLkQioyZ2BP9cfufxLam7FYq5tV68OjC0=,iv:F5wpFIHftza6GaSsxcVc3PB2FY9zXO4Xo79WTzOHpV4=,tag:jl2CQhR7ZdOxn+fVD0loOg==,type:str]
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-1:234878555361:key/54b96a99-ee11-4e46-93a7-7e3a130db583
-          created_at: "2024-11-08T15:04:12Z"
-          enc: AQICAHhWR/cL6re9GRvzeHMPbvB69g/BhSB9ZWifRozqB8kD1wGzjbPdXFu1WDxcTmliQHGsAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbLBpt+qBbzOjxkr2AgEQgDs4uUSj8KRtD0j7lUiQJyOcFT5dlPY0d1izvBq04eumHvM7jNdZzoNWWimGYtKhpEWd7Oo19GXSPilvbA==
+        - arn: arn:aws:kms:us-east-1:234878555361:key/6462da8d-e99d-4bb6-98d6-1b7e8561ecc0
+          created_at: "2026-05-09T01:06:46Z"
+          enc: AQICAHgY705ep75advMMNqjqFAU9HqzlXqPTLCbJkjBlZDv5CAFOyQU/gs7PnQqGo6Dw2ioMAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMVSq9eUhP2aiV1ofPAgEQgDutb6RvAHZsSIuAJGr3958MWjw93V/Nog5rF5H5C5k4jK4cVjZKfqvoykZLAGgXMGsD6AjwMZrDqCJ6Aw==
           aws_profile: ""
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2024-11-08T15:04:12Z"
-    mac: ENC[AES256_GCM,data:gO7xTvaJORmnIcGDm04YSBXAtz9MjrB4D6B0Fky9uboKrFdOF3cOJfdrMExKVSr92xsZp4G1X7hXY4hZa/qhmV9/6vSdL6b1KTOSNVoU7l35LiWxWsBJS7g2GysCoqA+P5l6eyz7nqb4R6V/bZbqFHGVOs+G1E5ni9wBlqes7aw=,iv:9WToYRveiK6IqdseiubIkse7CSsYuKClibeCTgYkSz0=,tag:UvtZ5q/m+W8DKGYBBKCXiA==,type:str]
-    pgp: []
+    lastmodified: "2026-05-09T01:06:47Z"
+    mac: ENC[AES256_GCM,data:aEBNH18zooH1G9DEx9EKsvU9VjonEjHbqdqKT2fepiOZgkWz0JwuMFRfHbAAPOCqBnincLzGCkq1nVfyaDEEE1OCorZFkUWsGkCMEgzyc7HUSzGNd0anE05rXFCvBpSIuJz4r2gBHqmrrypU5jg/8494Y6wr+NWVaL0rfJtyV24=,iv:cCYW3Xf2K9MtxLBbLAdIC+V2swF9iNRVRQBNnUF0lIE=,tag:NNxPQ5R+cNlulc3fwiAeog==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.12.2


### PR DESCRIPTION
## Summary

- Rotates the SOPS KMS encryption key to a new AWS KMS key for the kubernetes/aws secrets
- Re-encrypts all existing SOPS-managed secrets with the new key
- Upgrades SOPS version from 3.9.1 to 3.12.2

## Changes

1. **`.sops.yaml`**: Updated KMS key ARN from `54b96a99-ee11-4e46-93a7-7e3a130db583` to `6462da8d-e99d-4bb6-98d6-1b7e8561ecc0`
2. **`catalog/secret.yaml`**: Re-encrypted with new KMS key, cleaned up empty provider blocks (gcp_kms, azure_kv, hc_vault, age, pgp)
3. **`orders/mysql.yaml`**: Re-encrypted with new KMS key, cleaned up empty provider blocks
4. **`orders/secret.yaml`**: Re-encrypted with new KMS key, cleaned up empty provider blocks
5. **`rabbitmq/secret.yaml`**: Re-encrypted with new KMS key, cleaned up empty provider blocks