### PR TITLE
fix: Azure VMSS pool as static single worker (drop module autoscaler)

### DIFF
--- a/admin/outputs.tf
+++ b/admin/outputs.tf
@@ -49,15 +49,6 @@ output "azure_vmss_worker_pool_id" {
   value = spacelift_worker_pool.azure_vmss.id
 }
 
-output "azure_vmss_autoscaler_api_key_id" {
-  value = spacelift_api_key.azure_vmss_autoscaler.id
-}
-
-output "azure_vmss_autoscaler_api_key_secret" {
-  value     = spacelift_api_key.azure_vmss_autoscaler.secret
-  sensitive = true
-}
-
 // GCP Outputs //
 
 // Compute Engine worker pool outputs

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -66,7 +66,7 @@ module "stack_azure_linux" {
   }
 }
 
-# Stack that deploys the Azure VMSS worker pool (with autoscaler, min 1).
+# Stack that deploys the Azure VMSS worker pool (static, one always-on worker).
 # It runs on shared workers and uses the Azure integration to provision the VMSS;
 # the resulting workers register back to the pool created in the admin stack.
 module "stack_azure_vmss_worker_pool" {
@@ -103,14 +103,6 @@ module "stack_azure_vmss_worker_pool" {
         WORKER_POOL_PRIVATE_KEY = {
           output_name = "azure_vmss_worker_pool_private_key"
           input_name  = "TF_VAR_worker_pool_private_key"
-        }
-        AUTOSCALER_API_KEY_ID = {
-          output_name = "azure_vmss_autoscaler_api_key_id"
-          input_name  = "TF_VAR_spacelift_api_key_id"
-        }
-        AUTOSCALER_API_KEY_SECRET = {
-          output_name = "azure_vmss_autoscaler_api_key_secret"
-          input_name  = "TF_VAR_spacelift_api_key_secret"
         }
       }
     }

--- a/admin/worker_pools_azure_vmss.tf
+++ b/admin/worker_pools_azure_vmss.tf
@@ -19,19 +19,3 @@ resource "tls_cert_request" "azure_vmss" {
     organization = local.spacelift_hostname
   }
 }
-
-# API key used by the VMSS autoscaler to query the worker pool queue and drain workers.
-resource "spacelift_api_key" "azure_vmss_autoscaler" {
-  name = "azure-vmss-autoscaler"
-}
-
-# Built-in system role for worker pool automation (SPACE_READ + WORKER_POOL_*).
-data "spacelift_role" "worker_pool_controller" {
-  slug = "worker-pool-controller"
-}
-
-resource "spacelift_role_attachment" "azure_vmss_autoscaler" {
-  api_key_id = spacelift_api_key.azure_vmss_autoscaler.id
-  role_id    = data.spacelift_role.worker_pool_controller.role_id
-  space_id   = "root"
-}

--- a/worker-pools/docker/azure/vmss/main.tf
+++ b/worker-pools/docker/azure/vmss/main.tf
@@ -25,21 +25,12 @@ module "worker_pool_azure_vmss" {
   name_prefix = "sp5ft-demo"
   vmss_sku    = var.vmss_sku
 
-  # Autoscaler keeps a minimum of one warm worker so demo runs start instantly.
-  autoscaling_configuration = {
-    max_create    = 2
-    max_terminate = 1
-    scale = {
-      min = var.worker_pool_min_size
-      max = var.worker_pool_max_size
-    }
-  }
-
-  spacelift_api_credentials = {
-    api_key_id       = var.spacelift_api_key_id
-    api_key_secret   = var.spacelift_api_key_secret
-    api_key_endpoint = "${var.spacelift_api_key_endpoint}/graphql"
-  }
+  # Static single-worker pool: one always-warm worker (ideal for live demos).
+  # The module's autoscaler is intentionally not used here — it creates role
+  # assignments for its Function App identity, which requires roleAssignments/write
+  # that the Spacelift integration SP can't be granted under the subscription's
+  # ABAC guardrails.
+  non_autoscaled_vmss_instances = var.worker_count
 
   tags = {
     Environment = "demo"

--- a/worker-pools/docker/azure/vmss/variables.tf
+++ b/worker-pools/docker/azure/vmss/variables.tf
@@ -15,24 +15,6 @@ variable "worker_pool_id" {
   description = "ID of the Spacelift worker pool."
 }
 
-variable "spacelift_api_key_endpoint" {
-  type        = string
-  description = "Full URL of the Spacelift API endpoint, eg. https://spacelift-solutions.app.spacelift.io"
-  default     = "https://spacelift-solutions.app.spacelift.io"
-}
-
-variable "spacelift_api_key_id" {
-  type        = string
-  description = "ID of the Spacelift API key used by the autoscaler."
-  sensitive   = true
-}
-
-variable "spacelift_api_key_secret" {
-  type        = string
-  description = "Secret of the Spacelift API key used by the autoscaler."
-  sensitive   = true
-}
-
 variable "location" {
   type        = string
   description = "Azure region for the worker pool resources."
@@ -45,16 +27,10 @@ variable "vmss_sku" {
   default     = "Standard_B2S"
 }
 
-variable "worker_pool_min_size" {
+variable "worker_count" {
   type        = number
-  description = "Minimum number of workers the autoscaler keeps running."
+  description = "Number of always-on workers in the (non-autoscaled) pool."
   default     = 1
-}
-
-variable "worker_pool_max_size" {
-  type        = number
-  description = "Maximum number of workers the autoscaler may create."
-  default     = 5
 }
 
 variable "admin_username" {


### PR DESCRIPTION
## Why

The `terraform-azure-spacelift-workerpool` autoscaler **always** creates role assignments for its Function App identity (VM Contributor on the VMSS, Reader on the RG, Network Contributor on the subnet — no toggle to skip). That needs `Microsoft.Authorization/roleAssignments/write`, which:
- the managed integration SP doesn't have (only Contributor), and
- can't be granted — the subscription's **ABAC guardrail** blocks delegating any role-assignment-capable role (Owner/UAA/RBAC-Admin).

So the autoscaler can't deploy through Spacelift under current permissions. Apply failed on exactly those `azurerm_role_assignment` resources (everything else — RG, vnet, subnet, VMSS, Function App, KeyVault — created fine).

## Change

Switch the pool to a **static single always-on worker** (`non_autoscaled_vmss_instances = 1`). Ideal for a live demo (instant runs, no scale-up wait). Removes the now-unused autoscaler API key, `worker-pool-controller` role attachment, autoscaler outputs, and api-key variables.

Follow-up (separate): if we want the real queue-based autoscaler later, get a true admin to grant the integration SP `User Access Administrator`, then re-enable `autoscaling_configuration`.

`tofu validate` passes.