### PR TITLE
feat: Azure DevOps VCS integration + demo workload stack

### DIFF
--- a/admin/integrations_azure_devops.tf
+++ b/admin/integrations_azure_devops.tf
@@ -1,0 +1,36 @@
+variable "azure_devops_pat" {
+  type        = string
+  description = "Azure DevOps Personal Access Token for the VCS integration. Provided write-only via the azure-devops context (set the real value in the Spacelift UI)."
+  sensitive   = true
+  default     = "PLACEHOLDER_SET_VIA_UI"
+}
+
+# Azure DevOps VCS integration so stacks can source from dev.azure.com/spacelift-solutions.
+resource "spacelift_azure_devops_integration" "demo" {
+  name                  = "Azure DevOps"
+  organization_url      = "https://dev.azure.com/spacelift-solutions"
+  personal_access_token = var.azure_devops_pat
+  is_default            = true
+}
+
+# Holds the ADO PAT as a write-only env var (set the real value in the UI, same
+# pattern as the spacelift-monitoring context). Attached to the admin stack so
+# the integration above can read it at apply time.
+resource "spacelift_context" "azure_devops" {
+  name        = "azure-devops-pat"
+  description = "Azure DevOps PAT for the VCS integration (value set write-only via UI)"
+  space_id    = "root"
+}
+
+resource "spacelift_environment_variable" "azure_devops_pat" {
+  context_id = spacelift_context.azure_devops.id
+  name       = "TF_VAR_azure_devops_pat"
+  value      = "PLACEHOLDER_SET_VIA_UI"
+  write_only = true
+}
+
+resource "spacelift_context_attachment" "azure_devops_admin" {
+  context_id = spacelift_context.azure_devops.id
+  stack_id   = data.spacelift_current_stack.admin.id
+  priority   = 0
+}

--- a/admin/policies.tf
+++ b/admin/policies.tf
@@ -1,3 +1,12 @@
+resource "spacelift_policy" "azure_large_vm_sku_approval" {
+  name        = "Azure - require approval for large VM SKUs"
+  body        = file("./policies/approval/azure_large_vm_sku_approval.rego")
+  type        = "APPROVAL"
+  description = "Requires a human approval before applying runs that create or change an Azure VM with a large SKU. Auto-approves smaller SKUs."
+  labels      = ["autoattach:azure-demo-app"]
+  space_id    = "root"
+}
+
 resource "spacelift_policy" "trigger_consumers" {
   name        = "trigger module consumers"
   body        = file("./policies/trigger/trigger_module_consumers.rego")

--- a/admin/policies/approval/azure_large_vm_sku_approval.rego
+++ b/admin/policies/approval/azure_large_vm_sku_approval.rego
@@ -1,0 +1,49 @@
+package spacelift
+
+# Require a human approval before applying any run that creates or changes an
+# Azure VM with a "large" SKU. Smaller SKUs are auto-approved so routine changes
+# flow through without friction.
+
+# Large Azure VM SKUs that require manual approval.
+large_vm_sizes := {
+	"Standard_D8s_v5",
+	"Standard_D16s_v5",
+	"Standard_D32s_v5",
+	"Standard_D8s_v4",
+	"Standard_D16s_v4",
+	"Standard_D32s_v4",
+	"Standard_E8s_v5",
+	"Standard_E16s_v5",
+	"Standard_E32s_v5",
+	"Standard_F8s_v2",
+	"Standard_F16s_v2",
+	"Standard_F32s_v2",
+}
+
+# True if the run creates or updates an Azure VM with a large SKU.
+requests_large_vm {
+	some i
+	change := input.run.changes[i]
+	change.action != "deleted"
+	change.entity.type == "azurerm_linux_virtual_machine"
+	large_vm_sizes[change.entity.data.size]
+}
+
+# Auto-approve runs that do not request a large VM SKU.
+approve {
+	not requests_large_vm
+}
+
+# When a large VM SKU is requested, require at least one human approval.
+approve {
+	requests_large_vm
+	count(input.reviews.current.approvals) > 0
+}
+
+# Anyone may block a run by rejecting it.
+reject {
+	count(input.reviews.current.rejections) > 0
+}
+
+# Sample evaluations so we can inspect inputs from the policy view.
+sample := true

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -108,3 +108,36 @@ module "stack_azure_vmss_worker_pool" {
     }
   }
 }
+
+# Demo workload stack — sourced from the Azure DevOps repo, runs on the Azure
+# VMSS worker pool. Demonstrates the PR workflow and the large-VM-SKU approval
+# policy. Uses the raw spacelift_stack resource because the stacks module does
+# not support Azure DevOps as a VCS provider.
+resource "spacelift_stack" "azure_demo_app" {
+  name        = "azure-demo-app"
+  description = "Demo: deploys an Azure VM from Azure DevOps; gated by the large-VM-SKU approval policy."
+  space_id    = spacelift_space.azure_terraform.id
+
+  repository = "demo"
+  branch     = "main"
+
+  azure_devops {
+    id      = spacelift_azure_devops_integration.demo.id
+    project = "demo"
+  }
+
+  terraform_workflow_tool = "OPEN_TOFU"
+  terraform_version       = "1.8.4"
+  worker_pool_id          = spacelift_worker_pool.azure_vmss.id
+  autodeploy              = false
+
+  labels = ["azure", "demo", "azure-demo-app"]
+}
+
+resource "spacelift_azure_integration_attachment" "azure_demo_app" {
+  integration_id  = data.spacelift_azure_integration.demo.id
+  stack_id        = spacelift_stack.azure_demo_app.id
+  subscription_id = data.spacelift_azure_integration.demo.default_subscription_id
+  read            = true
+  write           = true
+}


### PR DESCRIPTION
## What

Wires up the Azure DevOps source for the Azure demo:
- **`integrations_azure_devops.tf`** — `spacelift_azure_devops_integration` (org `spacelift-solutions`), default integration. PAT supplied **write-only via a new `azure-devops-pat` context**.
- **`stacks_opentofu_azure.tf`** — `azure-demo-app` stack sourcing the ADO **`demo`** repo (project `demo`), running on the **Azure VMSS worker pool**, with the managed Azure integration attached. Uses the raw `spacelift_stack` resource (the stacks module doesn't support Azure DevOps as a VCS provider).
- **`policies/approval/azure_large_vm_sku_approval.rego`** — APPROVAL policy requiring a human approval for runs that create/change an Azure VM with a large SKU; auto-approves smaller ones. Auto-attached via the `azure-demo-app` label.

The ADO repo is already seeded with the workload TF (RG + network + Linux VM with a `vm_size` knob).

## Action needed: the PAT (write-only)

After merge: set the real value of `TF_VAR_azure_devops_pat` on the **`azure-devops-pat`** context in the Spacelift UI, then re-run Admin so the integration picks it up. (PAT scopes: Code Read & Write + Service Hooks Read & Manage.)