### PR TITLE
fix: reference Azure DevOps integration via data source

### DIFF
--- a/admin/integrations_azure_devops.tf
+++ b/admin/integrations_azure_devops.tf
@@ -1,36 +1,5 @@
-variable "azure_devops_pat" {
-  type        = string
-  description = "Azure DevOps Personal Access Token for the VCS integration. Provided write-only via the azure-devops context (set the real value in the Spacelift UI)."
-  sensitive   = true
-  default     = "PLACEHOLDER_SET_VIA_UI"
-}
-
-# Azure DevOps VCS integration so stacks can source from dev.azure.com/spacelift-solutions.
-resource "spacelift_azure_devops_integration" "demo" {
-  name                  = "Azure DevOps"
-  organization_url      = "https://dev.azure.com/spacelift-solutions"
-  personal_access_token = var.azure_devops_pat
-  is_default            = true
-}
-
-# Holds the ADO PAT as a write-only env var (set the real value in the UI, same
-# pattern as the spacelift-monitoring context). Attached to the admin stack so
-# the integration above can read it at apply time.
-resource "spacelift_context" "azure_devops" {
-  name        = "azure-devops-pat"
-  description = "Azure DevOps PAT for the VCS integration (value set write-only via UI)"
-  space_id    = "root"
-}
-
-resource "spacelift_environment_variable" "azure_devops_pat" {
-  context_id = spacelift_context.azure_devops.id
-  name       = "TF_VAR_azure_devops_pat"
-  value      = "PLACEHOLDER_SET_VIA_UI"
-  write_only = true
-}
-
-resource "spacelift_context_attachment" "azure_devops_admin" {
-  context_id = spacelift_context.azure_devops.id
-  stack_id   = data.spacelift_current_stack.admin.id
-  priority   = 0
-}
+# The Azure DevOps VCS integration is created imperatively (the pinned spacelift
+# provider version predates the spacelift_azure_devops_integration resource).
+# Look it up via data source, the same way the managed Azure cloud integration
+# is referenced.
+data "spacelift_azure_devops_integration" "demo" {}

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -122,7 +122,7 @@ resource "spacelift_stack" "azure_demo_app" {
   branch     = "main"
 
   azure_devops {
-    id      = spacelift_azure_devops_integration.demo.id
+    id      = data.spacelift_azure_devops_integration.demo.id
     project = "demo"
   }
 


### PR DESCRIPTION
## Why

The admin apply for #159 failed: the pinned spacelift provider (**1.43.0**) doesn't support the `spacelift_azure_devops_integration` **resource** (added in a later provider version). `main` is currently broken.

## Fix

The ADO integration is created out-of-band (the default integration, same approach as the managed Azure **cloud** integration), referenced via the **data source** `spacelift_azure_devops_integration` — which *is* present in 1.43.0. Drops the now-unneeded PAT variable + `azure-devops-pat` context.

No provider bump needed (avoids churning the account control-plane provider).