### PR TITLE
feat: pass triage_project_token to support-comment workflow

### DIFF
--- a/.github/workflows/support-comment.yaml
+++ b/.github/workflows/support-comment.yaml
@@ -14,3 +14,4 @@ jobs:
     uses: spacelift-io/.github/.github/workflows/support-comment.yaml@main
     secrets:
       slack_webhook_url: ${{ secrets.SUPPORT_SLACK_WEBHOOK_URL }}
+      triage_project_token: ${{ secrets.SUPPORT_TRIAGE_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Pass the new `triage_project_token` secret to the shared `support-comment` reusable workflow.

`spacelift-io/.github` is adding a step that places new issues/PRs on the Spacelift Triage Board. That step needs a cross-org token, exposed to the reusable workflow as the `triage_project_token` secret. This PR wires it through from this repo.

See spacelift-io/.github#1 for the reusable-workflow change.

## Changes

1. **`.github/workflows/support-comment.yaml`**: pass `triage_project_token: ${{ secrets.SUPPORT_TRIAGE_PROJECT_TOKEN }}` alongside the existing `slack_webhook_url` secret.

Requires the `SUPPORT_TRIAGE_PROJECT_TOKEN` secret to be present (set as an org-level Actions secret).