### PR TITLE
feat: wire GitHub auth + deletion-prevention contexts into CloudWatch dashboard stack

### DIFF
--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -1,0 +1,6 @@
+resource "spacelift_context" "github_auth" {
+  description = "GitHub authentication context for stack runs"
+  name        = "github-auth"
+  space_id    = spacelift_space.aws_opentofu.id
+  labels      = ["autoattach:github-auth"]
+}

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,24 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention"]
+  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
   project_root      = "opentofu/aws/cloudwatch_dashboard"
   repository_branch = "main"
+
+  hooks = {
+    before = {
+      init = [
+        "echo 'Preparing CloudWatch dashboard stack deployment'"
+      ]
+    }
+  }
+
+  contexts = {
+    deletion_prevention = {
+      enabled = true
+    }
+    github_auth = spacelift_context.github_auth.id
+  }
 
   policies = {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,10 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
-  project_root      = "opentofu/aws/cloudwatch_dashboard"
-  repository_branch = "main"
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
+  project_root          = "opentofu/aws/cloudwatch_dashboard"
+  repository_branch     = "main"
+  protect_from_deletion = true
 
   hooks = {
     before = {
@@ -220,9 +221,6 @@ module "stack_aws_cloudwatch_dashboard" {
   }
 
   contexts = {
-    deletion_prevention = {
-      enabled = true
-    }
     github_auth = spacelift_context.github_auth.id
   }
 


### PR DESCRIPTION
## Summary
- Adds a `github_auth` Spacelift context (`admin/contexts_github.tf`)
- Wires a `before.init` hook, the `deletion_prevention` / `github_auth` contexts, and a `wiz` label into the `stack_aws_cloudwatch_dashboard` module block (`admin/stacks_opentofu_aws.tf`)

History on this branch was squashed (32 commits -> 1) and rebased onto current `main`; most of the original CloudWatch dashboard / policy work had already landed on `main` via earlier PRs (#151-#156), so this PR's real diff is now small.

## Known issue (flagged in review, not yet fixed)
`contexts = { deletion_prevention = { enabled = true }, github_auth = ... }` mixes an object and a string value in one map. The wrapped `stacks-module`'s `contexts` variable is `map(string)` with no `deletion_prevention`/`enabled` feature (deletion protection there is a separate `protect_from_deletion` bool, currently unset). This will likely fail type-checking on `tofu plan`, or silently no-op deletion protection if coerced.

## Test plan
- [ ] `tofu plan` on the admin stack to confirm the `contexts` block type-checks
- [ ] Confirm the `github_auth` context actually attaches to the dashboard stack run
