### PR TITLE
AWS CloudWatch dashboard stack with github-auth context

### DIFF
--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -4,3 +4,31 @@ resource "spacelift_context" "github_auth" {
   space_id    = spacelift_space.aws_opentofu.id
   labels      = ["autoattach:github-auth"]
 }
+
+resource "spacelift_environment_variable" "context_secret" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_SECRET"
+  value      = "thisisasecret"
+  write_only = true
+}
+
+resource "spacelift_environment_variable" "context_public" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_PUBLIC"
+  value      = "This should be visible"
+  write_only = false
+}
+
+resource "spacelift_mounted_file" "context_secret" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_SECRET"
+  content       = base64encode("thisisasecret")
+  write_only    = true
+}
+
+resource "spacelift_mounted_file" "context_public" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_PUBLIC"
+  content       = base64encode("This should be visible")
+  write_only    = false
+}

--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -1,0 +1,6 @@
+resource "spacelift_context" "github_auth" {
+  description = "GitHub authentication context for stack runs"
+  name        = "github-auth"
+  space_id    = spacelift_space.aws_opentofu.id
+  labels      = ["autoattach:github-auth"]
+}

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,24 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention"]
+  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
   project_root      = "opentofu/aws/cloudwatch_dashboard"
   repository_branch = "main"
+
+  hooks = {
+    before = {
+      init = [
+        "echo 'Preparing CloudWatch dashboard stack deployment'"
+      ]
+    }
+  }
+
+  contexts = {
+    deletion_prevention = {
+      enabled = true
+    }
+    github_auth = spacelift_context.github_auth.id
+  }
 
   policies = {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,10 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
-  project_root      = "opentofu/aws/cloudwatch_dashboard"
-  repository_branch = "main"
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
+  project_root          = "opentofu/aws/cloudwatch_dashboard"
+  repository_branch     = "main"
+  protect_from_deletion = true
 
   hooks = {
     before = {
@@ -220,9 +221,6 @@ module "stack_aws_cloudwatch_dashboard" {
   }
 
   contexts = {
-    deletion_prevention = {
-      enabled = true
-    }
     github_auth = spacelift_context.github_auth.id
   }
 


### PR DESCRIPTION
## Summary
- Add the tofu-cloudwatch-dashboard stack (CloudWatch dashboard with ALB/RDS metrics) with deletion-prevention and two-person review policy
- Add CONTEXT_SECRET/CONTEXT_PUBLIC environment variables and matching mounted files to the github-auth context attached to that stack

## Test plan
- [ ] `tofu plan` on the admin stack shows the expected context/env var/mounted file resources
- [ ] Verify CONTEXT_SECRET is hidden (write-only) and CONTEXT_PUBLIC is visible in the Spacelift UI after apply
- [ ] Confirm the cloudwatch dashboard stack run succeeds with the context attached