### PR TITLE
feat: Add stack dependencies and scheduled task to CloudWatch dashboard stack

### DIFF
--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -4,3 +4,31 @@ resource "spacelift_context" "github_auth" {
   space_id    = spacelift_space.aws_opentofu.id
   labels      = ["autoattach:github-auth"]
 }
+
+resource "spacelift_environment_variable" "context_secret" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_SECRET"
+  value      = "thisisasecret"
+  write_only = true
+}
+
+resource "spacelift_environment_variable" "context_public" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_PUBLIC"
+  value      = "This should be visible"
+  write_only = false
+}
+
+resource "spacelift_mounted_file" "context_secret" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_SECRET"
+  content       = base64encode("thisisasecret")
+  write_only    = true
+}
+
+resource "spacelift_mounted_file" "context_public" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_PUBLIC"
+  content       = base64encode("This should be visible")
+  write_only    = false
+}

--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -1,0 +1,6 @@
+resource "spacelift_context" "github_auth" {
+  description = "GitHub authentication context for stack runs"
+  name        = "github-auth"
+  space_id    = spacelift_space.aws_opentofu.id
+  labels      = ["autoattach:github-auth"]
+}

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -228,4 +228,21 @@ module "stack_aws_cloudwatch_dashboard" {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id
   }
+
+  dependencies = {
+    ADMIN = {
+      parent_stack_id = data.spacelift_current_stack.admin.id
+    }
+    OPENTOFU_AWS_S3 = {
+      child_stack_id = module.stack_opentofu_aws_s3.id
+    }
+  }
+}
+
+resource "spacelift_scheduled_task" "cloudwatch_dashboard_version_check" {
+  stack_id = module.stack_aws_cloudwatch_dashboard.id
+
+  command  = "tofu version && ls -la"
+  every    = ["*/15 * * * *"]
+  timezone = "UTC"
 }

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,24 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention"]
+  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
   project_root      = "opentofu/aws/cloudwatch_dashboard"
   repository_branch = "main"
+
+  hooks = {
+    before = {
+      init = [
+        "echo 'Preparing CloudWatch dashboard stack deployment'"
+      ]
+    }
+  }
+
+  contexts = {
+    deletion_prevention = {
+      enabled = true
+    }
+    github_auth = spacelift_context.github_auth.id
+  }
 
   policies = {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -228,15 +228,6 @@ module "stack_aws_cloudwatch_dashboard" {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id
   }
-
-  dependencies = {
-    ADMIN = {
-      parent_stack_id = data.spacelift_current_stack.admin.id
-    }
-    OPENTOFU_AWS_S3 = {
-      child_stack_id = module.stack_opentofu_aws_s3.id
-    }
-  }
 }
 
 resource "spacelift_scheduled_task" "cloudwatch_dashboard_version_check" {

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,10 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
-  project_root      = "opentofu/aws/cloudwatch_dashboard"
-  repository_branch = "main"
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
+  project_root          = "opentofu/aws/cloudwatch_dashboard"
+  repository_branch     = "main"
+  protect_from_deletion = true
 
   hooks = {
     before = {
@@ -220,9 +221,6 @@ module "stack_aws_cloudwatch_dashboard" {
   }
 
   contexts = {
-    deletion_prevention = {
-      enabled = true
-    }
     github_auth = spacelift_context.github_auth.id
   }
 


### PR DESCRIPTION
## Summary
- Add a "Depends on" dependency from tofu-cloudwatch-dashboard to the admin stack
- Add a "Depended on by" relationship so opentofu-aws-s3 depends on tofu-cloudwatch-dashboard
- Add a scheduled task running `tofu version && ls -la` every 15 minutes on the stack

## Test plan
- [ ] Confirm the cloudwatch dashboard stack shows admin under "Depends on" and opentofu-aws-s3 under "Depended on by"
- [ ] Confirm the scheduled task appears under Scheduling and runs on the 15-minute cron