### PR TITLE
CloudWatch dashboard: require-project-tag policy, weekend blocking, drop wiz scan

### DIFF
--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -4,3 +4,31 @@ resource "spacelift_context" "github_auth" {
   space_id    = spacelift_space.aws_opentofu.id
   labels      = ["autoattach:github-auth"]
 }
+
+resource "spacelift_environment_variable" "context_secret" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_SECRET"
+  value      = "thisisasecret"
+  write_only = true
+}
+
+resource "spacelift_environment_variable" "context_public" {
+  context_id = spacelift_context.github_auth.id
+  name       = "CONTEXT_PUBLIC"
+  value      = "This should be visible"
+  write_only = false
+}
+
+resource "spacelift_mounted_file" "context_secret" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_SECRET"
+  content       = base64encode("thisisasecret")
+  write_only    = true
+}
+
+resource "spacelift_mounted_file" "context_public" {
+  context_id    = spacelift_context.github_auth.id
+  relative_path = "CONTEXT_PUBLIC"
+  content       = base64encode("This should be visible")
+  write_only    = false
+}

--- a/admin/contexts_github.tf
+++ b/admin/contexts_github.tf
@@ -1,0 +1,6 @@
+resource "spacelift_context" "github_auth" {
+  description = "GitHub authentication context for stack runs"
+  name        = "github-auth"
+  space_id    = spacelift_space.aws_opentofu.id
+  labels      = ["autoattach:github-auth"]
+}

--- a/admin/policies.tf
+++ b/admin/policies.tf
@@ -83,3 +83,12 @@ resource "spacelift_policy" "no-weekend-deploys" {
   labels   = ["autoattach:deletion-prevention"]
   space_id = spacelift_space.aws_opentofu.id
 }
+
+resource "spacelift_policy" "require_project_tag" {
+  name        = "Require 'project' tag on all resources"
+  body        = file("./policies/plan/require_project_tag.rego")
+  type        = "PLAN"
+  description = "Fails the plan if any created/updated resource that supports tags is missing a 'project' tag. Opt in by adding the 'require-project-tag' label to a stack."
+  labels      = ["autoattach:require-project-tag"]
+  space_id    = spacelift_space.aws_opentofu.id
+}

--- a/admin/policies/plan/no-weekend-deploys.rego
+++ b/admin/policies/plan/no-weekend-deploys.rego
@@ -2,10 +2,18 @@ package spacelift
 
 import rego.v1
 
-# Plan policy: deletion protection & no weekend deploys
-# Blocks resource deletions and prevents runs on weekends
+# Plan policy: deletion protection & no weekend runs
 
-# Collect deleted resource addresses
+weekend_timezone := "EST"
+
+now := input.request.timestamp_ns
+
+is_weekend if {
+	day := time.weekday([now, weekend_timezone])
+	day in {"Saturday", "Sunday"}
+}
+
+# --- Deletion protection: blocks deletions every day ---
 deleted_addresses contains addr if {
 	c := input.run.changes[_]
 	c.entity.entity_type == "resource"
@@ -13,7 +21,6 @@ deleted_addresses contains addr if {
 	addr := c.entity.address
 }
 
-# Deny if any resource is scheduled for deletion
 deny contains msg if {
 	count(deleted_addresses) > 0
 	msg := sprintf(
@@ -22,8 +29,8 @@ deny contains msg if {
 	)
 }
 
-# NOTE: Weekend blocking is left as a TODO because run timestamp handling
-# depends on the platform's timestamp format. Implement with accurate
-# timezone-aware parsing if you need strict weekend enforcement.
-
-sample := true
+# --- Weekend protection: blocks ALL runs on Sat/Sun ---
+deny contains msg if {
+	is_weekend
+	msg := "No runs allowed on weekends (EST)"
+}

--- a/admin/policies/plan/require_project_tag.rego
+++ b/admin/policies/plan/require_project_tag.rego
@@ -1,0 +1,38 @@
+package spacelift
+
+import rego.v1
+
+# Plan policy: every taggable resource being created or updated must carry a
+# "project" tag (key match is case-insensitive) so it can be traced back to
+# the project it belongs to. Resources whose schema has no "tags" attribute
+# (data sources, IAM policy documents, spacelift_* resources, etc.) are
+# skipped since there's nothing to tag.
+
+is_creating_or_updating(rc) if {
+	some action in rc.change.actions
+	action in {"create", "update"}
+}
+
+has_tags_attribute(rc) if {
+	"tags" in object.keys(rc.change.after)
+}
+
+has_project_tag(rc) if {
+	some key
+	rc.change.after.tags[key]
+	lower(key) == "project"
+}
+
+missing_project_tag contains rc.address if {
+	rc := input.terraform.resource_changes[_]
+	is_creating_or_updating(rc)
+	has_tags_attribute(rc)
+	not has_project_tag(rc)
+}
+
+deny contains msg if {
+	some address in missing_project_tag
+	msg := sprintf("Resource %s is missing a required 'project' tag.", [address])
+}
+
+sample := true

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -228,4 +228,21 @@ module "stack_aws_cloudwatch_dashboard" {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id
   }
+
+  dependencies = {
+    ADMIN = {
+      parent_stack_id = data.spacelift_current_stack.admin.id
+    }
+    OPENTOFU_AWS_S3 = {
+      child_stack_id = module.stack_opentofu_aws_s3.id
+    }
+  }
+}
+
+resource "spacelift_scheduled_task" "cloudwatch_dashboard_version_check" {
+  stack_id = module.stack_aws_cloudwatch_dashboard.id
+
+  command  = "tofu version && ls -la"
+  every    = ["*/15 * * * *"]
+  timezone = "UTC"
 }

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,7 +207,7 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz", "require-project-tag"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"
   protect_from_deletion = true

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,24 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention"]
+  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
   project_root      = "opentofu/aws/cloudwatch_dashboard"
   repository_branch = "main"
+
+  hooks = {
+    before = {
+      init = [
+        "echo 'Preparing CloudWatch dashboard stack deployment'"
+      ]
+    }
+  }
+
+  contexts = {
+    deletion_prevention = {
+      enabled = true
+    }
+    github_auth = spacelift_context.github_auth.id
+  }
 
   policies = {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -228,15 +228,6 @@ module "stack_aws_cloudwatch_dashboard" {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id
   }
-
-  dependencies = {
-    ADMIN = {
-      parent_stack_id = data.spacelift_current_stack.admin.id
-    }
-    OPENTOFU_AWS_S3 = {
-      child_stack_id = module.stack_opentofu_aws_s3.id
-    }
-  }
 }
 
 resource "spacelift_scheduled_task" "cloudwatch_dashboard_version_check" {

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,9 +207,10 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels            = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
-  project_root      = "opentofu/aws/cloudwatch_dashboard"
-  repository_branch = "main"
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz"]
+  project_root          = "opentofu/aws/cloudwatch_dashboard"
+  repository_branch     = "main"
+  protect_from_deletion = true
 
   hooks = {
     before = {
@@ -220,9 +221,6 @@ module "stack_aws_cloudwatch_dashboard" {
   }
 
   contexts = {
-    deletion_prevention = {
-      enabled = true
-    }
     github_auth = spacelift_context.github_auth.id
   }
 

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,7 +207,7 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz", "require-project-tag"]
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"
   protect_from_deletion = true
@@ -223,7 +223,7 @@ module "stack_aws_cloudwatch_dashboard" {
   contexts = {
     github_auth = spacelift_context.github_auth.id
   }
-
+  #these are the policies that will be applied to this stack, they are defined in the admin/policies.tf file
   policies = {
     TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id


### PR DESCRIPTION
## Summary
- Add a new PLAN policy (`require_project_tag.rego`) that fails a run if a created/updated resource with a `tags` attribute is missing a `project` tag (case-insensitive key match); registered as `spacelift_policy.require_project_tag`, auto-attaching via the `autoattach:require-project-tag` label, and attached to the CloudWatch dashboard stack
- Implement weekend run blocking in `no-weekend-deploys.rego` — denies all runs on Sat/Sun (EST) via `time.weekday`, filling in the previous TODO
- Drop the `wiz` label from the CloudWatch dashboard stack so the Wiz plugin's scan hook stops attaching (currently failing on a Wiz-side permissions issue unrelated to this repo)

## Test plan
- [ ] `tofu plan` succeeds and the new policy resource is created
- [ ] Trigger a run on the CloudWatch dashboard stack and verify the plan fails when a taggable resource lacks a `project` tag, and succeeds once tagged
- [ ] Verify a run triggered on a Saturday/Sunday (EST) is denied by the plan policy
- [ ] Confirm the CloudWatch dashboard stack no longer runs the Wiz scan hook