### PR TITLE
feat: add demo S3 bucket without project tag

### DIFF
--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -87,3 +87,13 @@ output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
 
+resource "aws_s3_bucket" "demo_bucket" {
+  bucket = "spacelift-demo-bucket-123awd456"
+  tags = {
+    environment = var.environment
+    managed_by  = "spacelift-demo"
+    budget      = "10000"
+    design      = "Scrum"
+    workflow    = "Waterfall"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `aws_s3_bucket.demo_bucket` to `opentofu/aws/cloudwatch_dashboard/main.tf` with tags that intentionally omit `project`

## Demo purpose
- The `tofu-cloudwatch-dashboard` stack has the `require-project-tag` label, which auto-attaches the `require_project_tag` PLAN policy (`admin/policies/plan/require_project_tag.rego`)
- Expected: the plan check on this PR should be **denied** by that policy, since `demo_bucket` has a `tags` block with no `project` key

## Test plan
- [x] `tofu fmt` — clean
- [x] `tofu validate` — passes
- [ ] Confirm Spacelift denies the plan for the missing project tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)