### PR TITLE
Update payments-api-prod CloudWatch dashboard metrics

### DIFF
--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,7 +207,7 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz", "require-project-tag"]
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"
   protect_from_deletion = true

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,7 +207,7 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag"]
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "wiz", "require-project-tag"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"
   protect_from_deletion = true

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -17,9 +17,9 @@ variable "alb_arn_suffix" {
   default = "app/Spacelift-ALB/701b9c7295718017"
 }
 
-variable "rds_instance_id" {
+variable "eks_cluster_name" {
   type    = string
-  default = "payments-prod-db"
+  default = "eks-cluster"
 }
 
 locals {
@@ -32,14 +32,13 @@ locals {
         width  = 12
         height = 6
         properties = {
-          title  = "ALB Request Count & 5XX"
+          title  = "ALB Peak LCUs"
           region = "us-east-1"
           metrics = [
-            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", var.alb_arn_suffix],
-            [".", "HTTPCode_ELB_5XX_Count", ".", "."],
+            ["AWS/ApplicationELB", "PeakLCUs", "LoadBalancer", var.alb_arn_suffix],
           ]
-          stat   = "Sum"
-          period = 60
+          stat   = "Average"
+          period = 300
         }
       },
       {
@@ -49,27 +48,44 @@ locals {
         width  = 12
         height = 6
         properties = {
-          title  = "ALB Target Latency p95"
+          title  = "Estimated Charges (USD)"
           region = "us-east-1"
           metrics = [
-            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", var.alb_arn_suffix, { stat = "p95" }],
+            ["AWS/Billing", "EstimatedCharges", "Currency", "USD"],
           ]
-          period = 60
+          stat   = "Maximum"
+          period = 21600
         }
       },
       {
         type   = "metric"
         x      = 0
         y      = 6
-        width  = 24
+        width  = 12
         height = 6
         properties = {
-          title  = "RDS CPU & Connections"
+          title  = "EC2 CPU Utilization"
           region = "us-east-1"
           metrics = [
-            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", var.rds_instance_id],
-            [".", "DatabaseConnections", ".", "."],
+            ["AWS/EC2", "CPUUtilization"],
           ]
+          stat   = "Average"
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title  = "EKS API Server 4XX Requests"
+          region = "us-east-1"
+          metrics = [
+            ["AWS/EKS", "apiserver_request_total_4XX", "ClusterName", var.eks_cluster_name],
+          ]
+          stat   = "Sum"
           period = 300
         }
       },
@@ -86,4 +102,3 @@ resource "aws_cloudwatch_dashboard" "this" {
 output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
-


### PR DESCRIPTION
## Summary
- Replace the payments-api-prod dashboard's ALB request/latency and RDS widgets with ALB PeakLCUs, Billing EstimatedCharges, EC2 CPUUtilization, and EKS `apiserver_request_total_4XX` widgets

## Notes
- `alb_arn_suffix` default already matches the live ALB (`app/Spacelift-ALB/701b9c7295718017`)
- `eks_cluster_name` defaults to `eks-cluster`, but no EKS cluster with that name currently exists in this AWS account/region, so that widget will show no data until one does
- This branch originally also re-added the `wiz` label to the stack, but that was reverted: the Wiz plugin's before-init hook is still broken (`chmod` fails on a missing `binary_install_wizcli.sh`), the same issue that caused the label to be dropped in commit 1765713. Left out until that's fixed.
- This stack has `TWO_PERSON_REVIEW` and `NO_WEEKEND_DEPLOYS` policies attached, so plan/apply timing should account for that

## Test plan
- [ ] Confirm Spacelift plan for `tofu-cloudwatch-dashboard` shows the expected widget diff
- [ ] After apply, verify `payments-api-prod` dashboard renders the 4 new widgets in the AWS console