### PR TITLE
Add RDS, EC2, ALB, and billing metrics to CloudWatch dashboard

### DIFF
--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -87,3 +87,13 @@ output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
 
+resource "aws_s3_bucket" "demo_bucket" {
+  bucket = "spacelift-demo-bucket-123awd456"
+  tags = {
+    environment = var.environment
+    managed_by  = "spacelift-demo"
+    budget      = "10000"
+    design      = "Scrum"
+    workflow    = "Waterfall"
+  }
+}

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -73,6 +73,78 @@ locals {
           period = 300
         }
       },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 24
+        height = 6
+        properties = {
+          title  = "Top 10 RDS Instances by Max CPU Utilization"
+          region = "us-east-1"
+          view   = "timeSeries"
+          stat   = "Average"
+          period = 300
+          metrics = [
+            [{
+              expression = "SELECT MAX(CPUUtilization) FROM SCHEMA(\"AWS/RDS\", DBInstanceIdentifier) GROUP BY DBInstanceIdentifier ORDER BY MAX() DESC LIMIT 10"
+              id         = "q1"
+            }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 6
+        properties = {
+          title  = "EC2 Average CPU Utilization"
+          region = "us-east-1"
+          view   = "timeSeries"
+          stat   = "Average"
+          period = 300
+          metrics = [
+            [{
+              expression = "SELECT AVG(CPUUtilization) FROM SCHEMA(\"AWS/EC2\", InstanceId)"
+              id         = "q2"
+            }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 24
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ALB Peak LCUs"
+          region = "us-east-1"
+          metrics = [
+            ["AWS/ApplicationELB", "PeakLCUs", "LoadBalancer", var.alb_arn_suffix],
+          ]
+          stat   = "Average"
+          period = 60
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 24
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Estimated Charges (USD)"
+          region = "us-east-1"
+          metrics = [
+            ["AWS/Billing", "EstimatedCharges", "Currency", "USD"],
+          ]
+          stat   = "Maximum"
+          period = 21600
+        }
+      },
     ]
   })
 }

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -159,8 +159,16 @@ output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
 
+resource "random_string" "demo_bucket_suffix" {
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
 resource "aws_s3_bucket" "demo_bucket" {
-  bucket = "spacelift-demo-bucket-123awd456"
+  bucket = "spacelift-demo-bucket-${random_string.demo_bucket_suffix.result}"
   tags = {
     environment = var.environment
     managed_by  = "spacelift-demo"

--- a/opentofu/aws/cloudwatch_dashboard/versions.tf
+++ b/opentofu/aws/cloudwatch_dashboard/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.47"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a Metrics Insights widget showing the top 10 RDS instances by max CPU utilization
- Adds a Metrics Insights widget showing average EC2 CPU utilization across all instances
- Adds an ALB Peak LCUs widget
- Adds an AWS/Billing EstimatedCharges (USD) widget

## Note
This branch continues from `demo-missing-project-tag` (PR #169), so this diff includes that branch's changes (RDS widgets, ALB request count, demo S3 bucket) as well as `origin/main`'s dashboard has independently diverged via PR #170 with a different widget set for this same file. Expect a merge conflict / reconciliation between the two when merging.

## Test plan
- [ ] `tofu validate` / `tofu plan` on the cloudwatch_dashboard stack
- [ ] Confirm dashboard renders in AWS console with the new widgets