### PR TITLE
Add RDS/EC2/ALB/billing metrics, wiz label, and auto_deploy fix

### DIFF
--- a/admin/.terraform.lock.hcl
+++ b/admin/.terraform.lock.hcl
@@ -2,35 +2,74 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/random" {
-  version = "3.8.0"
+  version = "3.9.0"
   hashes = [
-    "h1:aEaTEHutDdKNaztKFmInhfzmZK0/OaVL8uxmncM9YF8=",
-    "zh:2d5e0bbfac7f15595739fe54a9ab8b8eea92fd6d879706139dad7ecaa5c01c19",
-    "zh:349e637066625d97aaa84db1b1418c86d6457cf9c5a62f6dcc3f55cbd535112c",
-    "zh:5f4456d53f5256ccfdb87dd35d3bf34578d01bd9b71cffaf507f0692805eac8a",
-    "zh:6c1ecfacc5f7079a068d7f8eb8924485d4ec8183f36e6318a6e748d35921ddac",
-    "zh:6d86641edeb8c394f121f7b0a691d72f89cf9b938b987a01fc32aad396a50555",
-    "zh:76947bd7bc7033b33980538da149c94e386f9b0abb2ce63733f25a57517e4742",
-    "zh:79c07f4c8b3a63d9f89e25e4348b462c57e179bca66ba533710851c485e282db",
-    "zh:ac1c2b941d994728a3a93aba093fd2202f9311d099ff85f66678897c792161ba",
-    "zh:cbb2aa867fd828fcb4125239e00862b9a3bc2f280e945c760224276b476f4c49",
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:Lw9im2VBBJQ3RyAbHPQ0rcvcmmcZWm3x+kIOpN+Tv9s=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:YXaVd4p6qXPPVaxIBaIDNXmBwT02ZqDn0qD+tYpw8sA=",
+    "h1:cOpc03fphEt/G9Rfc4jLL/fW0D7tgvlXqiDKPF4vuww=",
+    "h1:g09RR7T1xWkeGrZwWvWMT9ncJrFGr1k3CBD585UmO7w=",
+    "h1:gGDdPPibmw2EWROx+sh1RGLjR5+nPwZyrf6/N9jXfeM=",
+    "h1:haE7/nXCOhXKP4oXeEnER3t5CaVQWqujz4nBnpeTUv4=",
+    "h1:ieSVpfZS2lKuMr05ph0QsOVpCzg7uk3cgKBaXR+Ikug=",
+    "h1:ig2s1IS9IzehorRjvVAnKIsUUj8fkgyxct1L/kswcc4=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "h1:lxezrKmOiQIySHAM+os8qLVq7hqufDr8h3Hpzvsk+78=",
+    "h1:lzRqBJAG+NETxHbEZUJ/YP3RMEjZBinTX7VmgH3lw60=",
+    "h1:tdSNWK5ApqUsgbdYieyeYLTu6nIZUV3hR1oFqUfAuGo=",
+    "h1:xedet8yH/zI2CfdxsGlK0nlFWc/Bp61yrWsEa3fHB8g=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
   ]
 }
 
 provider "registry.opentofu.org/hashicorp/tls" {
-  version = "4.1.0"
+  version = "4.3.0"
   hashes = [
-    "h1:yNZuPWUgw6Ik2huf9lhsuCGONWo2rsY1MfeceT0BQpw=",
-    "zh:187a99f0d236fd92da224e2f026c4ca8f1dcbf2b5cddc8e6896801bacfab0d73",
-    "zh:61a32a01cc46f382014dcf7aff5bcac61fe97bd69d3ccb51c801e9437ecdb9ce",
-    "zh:683ba18baa2cc336ff83f061b5e4569e2cd7c4a097b53a2d80bb0a26be2fc59a",
-    "zh:85c7640ea13dcf5ae5f7f3abbf2f21e4b93ce7f333ffee5b4a6acd6b5fe71223",
-    "zh:882f2c5214fd6d280a500acfd560925a71030ef70e10d11fa2b94815b58ae9b6",
-    "zh:97cb5e0b81b8687870a6b8a16e9a9cfe546e2fdb7534bdd8302eda0d66393f78",
-    "zh:c0a0110b15ce45140036fe5bf5a44cb822c2f55b30ff2770faf37d7c3cae3b5e",
-    "zh:d98c1c63fd0c76704fd7be38c316c305a2c95f3215330f2fb1e6b0b7081bf8e9",
-    "zh:e703a7adf220ac436f8ebfd06529de865b965fcfc461c7ef7b71afa0de04c8e9",
-    "zh:e93e241150cd438a0708679cb4aa7976742fde02f4c1725cfdefc405c4eeca1a",
+    "h1:+15bx0zcnqLz534Cbb8IC+FHMqfG55ELn+PxrQDA4gc=",
+    "h1:CzxZKtqwgNLbLx29KpIG8H3jOQFRkXCerkDRafS6PCg=",
+    "h1:EF8ln/osHphljZ9LNlqUICducYCjUq+PSaC2wBZM6cA=",
+    "h1:GizReb5vbh71HnhHlGphHhVFj3ghwAaC2MKqb2d8Ye8=",
+    "h1:O5oOot0y1MLb/j2gXVAOd20bPzM0daZyqgCk4kHbihg=",
+    "h1:SGBiqFFxGryTOiaNNWlC7CCba1hjSsSwcJeg6rOLJrc=",
+    "h1:UAV4fX41sizZ4U+FavGu3Fkgm4g7k8JD7BqBuhjMZ7o=",
+    "h1:ZxKvDInYHzss9rv75M778pInFm08ME6hY31XMyFP4IA=",
+    "h1:fpHTjAZkKqg+bRAiHmNzsMtYOPleAuK0hpdJxTLPtJE=",
+    "h1:hC3YGicct3gfUaMeY/Ci1MbS0ieDr6POkU8sudjkwKE=",
+    "h1:jJrKC+VUBdAAfBlcB06mNmlGskdd+MGoQI34hsMLItY=",
+    "h1:mmFJoeY9KBishP/zH8vvtpDekcqiYucgUGUnErhECAY=",
+    "h1:uMVBRi+9fgKgigHapewZE/BPiu/GfPvXlor/N7glFTk=",
+    "h1:xCRJdZECen3k+Qct+nUrUkUG5wpbeSiGHQGIJpgdkxg=",
+    "h1:xX++0TgL6lEWjSs33i3gI07CL1uIcOvUSweNkhvXK78=",
+    "zh:07bb8c6e64124dada7dff57a38a46f2f323b3fd77920404c0c550293d1cf6188",
+    "zh:0b3bfda2df39c52f1c5452d05cf3107bedd5d20ab6977c90ede540c695fb6c3e",
+    "zh:110a055289f0400a63ac172bedb0e671d059b7a5ba22d4a3f5f246ccac0ad676",
+    "zh:15e532d8c711377499dece832e60170a8bef39830125b8154f4bda81d9721d29",
+    "zh:22ca65d96e9fc1be5605372d855c9e1eba2d86d510f7ac8593968f5649435e47",
+    "zh:36df38dfd03e8c1298c5704fd85e28b69a3927ed0b339f9628d0b56dac99c6b5",
+    "zh:429e2bfcb81656e1fe90b7b284767d1453c1a4100b16d27e4b29c34aa12f0ce1",
+    "zh:5b6679953065f0279bf018426c6fb06dd93a851a7a9369f2e3a1fec5bc417e83",
+    "zh:6a72c88d5aa945ddb32041350755377c96681563136decfe7e05c7cdea7988f1",
+    "zh:6f05757c50da9f8354a735b5756bd63a71126fcd142129525b90c56bfd081d61",
+    "zh:751703b7a4d40c3a111c4ed0d5da3ec91c14f880faf6f010a5000a2eb5366011",
+    "zh:87a5279e61b8198798a2fe86cfe3b74e5340bb486f4e148bb5b4d46f860cf1db",
+    "zh:942af95e9fd73327a7e9ab0803c4d701b782ddacd78c9b7ce9c91e38b3051522",
+    "zh:a457d0efea3c404178a182d240ba21cdeb0c620ffabeeb9a8977b024a85e1360",
+    "zh:d5eac8f4f0ae1ff41cbcc1008e6a74a8491dc27f4c6e5a0c32c5c4b6ef2e4087",
   ]
 }
 
@@ -53,15 +92,21 @@ provider "registry.opentofu.org/opentofu/google" {
 }
 
 provider "registry.opentofu.org/spacelift-io/spacelift" {
-  version     = "1.43.0"
-  constraints = ">= 0.0.1, >= 1.1.4, >= 1.16.1, >= 1.42.0"
+  version     = "1.53.5"
+  constraints = ">= 0.0.1, >= 1.1.4, >= 1.42.0"
   hashes = [
-    "h1:j3iVcTZAhYrBzXI49J86SnU3VAJnWcdoiohNIEQuDcI=",
-    "zh:03e8f6732ad479172ff0d2e627db043dd5bbb72643d51283dc31a36c2ecb8dca",
-    "zh:31b16ee5b3d1893ad6d9c3bfbec9e18951767398effc61df6f35c32a0c5d6df1",
-    "zh:867eb560b555a4ce566fd456198e4f0f8226ffa0035e942c609427f26929aa23",
-    "zh:af8454be1dcb55ab95c6aa9b5f24cfcc5b1258049db38e011d6966a177793c28",
-    "zh:b0be943301da5878031e8ff5ab6d932b60589d0aa1d6d0914bae22738fa93185",
-    "zh:d9a12fccc027a8799cc5b7ae81ebc3e7004a3b8024f6eaa87f14da46287e6d39",
+    "h1:7yVRhdvP6PwUy0yimBxlVJcrmK6QRAPkeWvHGD1Z12o=",
+    "h1:9bDJZHfyZLyD3pJbJHR5VECVh8jTytiO6r3Nxu0Xt1I=",
+    "h1:HwgzqhDiw/HpEu4fT1bxX6Ctnnh/ooOEmyb1d38DXGs=",
+    "h1:MBubBdEYL1Pxgyk5l3dvKiWUr528ATKRpeu+WdnqXXg=",
+    "h1:vl31/9PxM86eR9wT69gFrqBMcf1djJgcvA+qLAiVD4I=",
+    "h1:wW05UFzeFCo86p+ii3EpR6zFJAQfsSOjxdbNZHKW0lQ=",
+    "zh:0beabb22de7fcf30cbc92762fde02a15aa8bf72b0e7440d1b96d56b9c80d3fcf",
+    "zh:373c23f2ce76ffa30857f48af2eecbbaacf193eb328341df523d57059251e0a3",
+    "zh:4ff24b4224c84d216a14be648623d1ca322e4e8e765ef59f59b23e82fdb4271f",
+    "zh:6818c7376ba4c9979989fad19c311b93e3dfd0fd002eff79daa22b35b03d462c",
+    "zh:6c717388a4f1fe37b00b29a57df9da7e0119adbfce87ba7cce78afcc4d4564dc",
+    "zh:747e265d6d968b39caf261c6ae50b9f0671462eb6ee7d04c62aa6e87c752b5b3",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -207,7 +207,7 @@ module "stack_aws_cloudwatch_dashboard" {
     id      = spacelift_aws_integration.demo.id
   }
 
-  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag"]
+  labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag", "wiz"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"
   protect_from_deletion = true
@@ -225,7 +225,6 @@ module "stack_aws_cloudwatch_dashboard" {
   }
   #these are the policies that will be applied to this stack, they are defined in the admin/policies.tf file
   policies = {
-    TWO_PERSON_REVIEW  = spacelift_policy.approval_cloudwatch_dashboard.id
     NO_WEEKEND_DEPLOYS = spacelift_policy.no-weekend-deploys.id
   }
 }

--- a/admin/stacks_opentofu_aws.tf
+++ b/admin/stacks_opentofu_aws.tf
@@ -206,7 +206,7 @@ module "stack_aws_cloudwatch_dashboard" {
     enabled = true
     id      = spacelift_aws_integration.demo.id
   }
-
+  #ensuring that the stack is protected from deletion and requires a project tag to be applied to the stack
   labels                = ["aws", "cloudwatch", "dashboard", "deletion-prevention", "require-project-tag", "wiz"]
   project_root          = "opentofu/aws/cloudwatch_dashboard"
   repository_branch     = "main"

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -81,7 +81,7 @@ module "stack_azure_vmss_worker_pool" {
   workflow_tool     = "OPEN_TOFU"
   tf_version        = "1.8.4"
   labels            = ["azure", "vmss", "worker-pool"]
-  auto_deploy       = true
+  autodeploy        = true
 
   azure_integration = {
     enabled         = true

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -81,7 +81,7 @@ module "stack_azure_vmss_worker_pool" {
   workflow_tool     = "OPEN_TOFU"
   tf_version        = "1.8.4"
   labels            = ["azure", "vmss", "worker-pool"]
-  autodeploy        = true
+  auto_deploy       = true
 
   azure_integration = {
     enabled         = true

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -81,7 +81,7 @@ module "stack_azure_vmss_worker_pool" {
   workflow_tool     = "OPEN_TOFU"
   tf_version        = "1.8.4"
   labels            = ["azure", "vmss", "worker-pool"]
-  autodeploy        = true
+  auto_deploy        = true
 
   azure_integration = {
     enabled         = true

--- a/admin/stacks_opentofu_azure.tf
+++ b/admin/stacks_opentofu_azure.tf
@@ -81,7 +81,7 @@ module "stack_azure_vmss_worker_pool" {
   workflow_tool     = "OPEN_TOFU"
   tf_version        = "1.8.4"
   labels            = ["azure", "vmss", "worker-pool"]
-  auto_deploy        = true
+  auto_deploy       = true
 
   azure_integration = {
     enabled         = true

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -87,3 +87,13 @@ output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
 
+resource "aws_s3_bucket" "demo_bucket" {
+  bucket = "spacelift-demo-bucket-123awd456"
+  tags = {
+    environment = var.environment
+    managed_by  = "spacelift-demo"
+    budget      = "10000"
+    design      = "Scrum"
+    workflow    = "Waterfall"
+  }
+}

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -73,6 +73,78 @@ locals {
           period = 300
         }
       },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 24
+        height = 6
+        properties = {
+          title  = "Top 10 RDS Instances by Max CPU Utilization"
+          region = "us-east-1"
+          view   = "timeSeries"
+          stat   = "Average"
+          period = 300
+          metrics = [
+            [{
+              expression = "SELECT MAX(CPUUtilization) FROM SCHEMA(\"AWS/RDS\", DBInstanceIdentifier) GROUP BY DBInstanceIdentifier ORDER BY MAX() DESC LIMIT 10"
+              id         = "q1"
+            }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 6
+        properties = {
+          title  = "EC2 Average CPU Utilization"
+          region = "us-east-1"
+          view   = "timeSeries"
+          stat   = "Average"
+          period = 300
+          metrics = [
+            [{
+              expression = "SELECT AVG(CPUUtilization) FROM SCHEMA(\"AWS/EC2\", InstanceId)"
+              id         = "q2"
+            }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 24
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ALB Peak LCUs"
+          region = "us-east-1"
+          metrics = [
+            ["AWS/ApplicationELB", "PeakLCUs", "LoadBalancer", var.alb_arn_suffix],
+          ]
+          stat   = "Average"
+          period = 60
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 24
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Estimated Charges (USD)"
+          region = "us-east-1"
+          metrics = [
+            ["AWS/Billing", "EstimatedCharges", "Currency", "USD"],
+          ]
+          stat   = "Maximum"
+          period = 21600
+        }
+      },
     ]
   })
 }

--- a/opentofu/aws/cloudwatch_dashboard/main.tf
+++ b/opentofu/aws/cloudwatch_dashboard/main.tf
@@ -159,8 +159,16 @@ output "dashboard_url" {
   value = "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=${aws_cloudwatch_dashboard.this.dashboard_name}"
 }
 
+resource "random_string" "demo_bucket_suffix" {
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
 resource "aws_s3_bucket" "demo_bucket" {
-  bucket = "spacelift-demo-bucket-123awd456"
+  bucket = "spacelift-demo-bucket-${random_string.demo_bucket_suffix.result}"
   tags = {
     environment = var.environment
     managed_by  = "spacelift-demo"

--- a/opentofu/aws/cloudwatch_dashboard/versions.tf
+++ b/opentofu/aws/cloudwatch_dashboard/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.47"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Randomize demo S3 bucket name
- Add RDS top-CPU, EC2 avg CPU, ALB peak LCUs, and billing metrics to CloudWatch dashboard
- Add demo S3 bucket without project tag
- Re-add wiz label and drop two-person review policy on the CloudWatch dashboard stack
- Fix `autodeploy` -> `auto_deploy` typo on the Azure VMSS worker pool stack

## Test plan
- [ ] `tofu plan` on the CloudWatch dashboard stack
- [ ] `tofu plan` on the Azure VMSS worker pool stack